### PR TITLE
fix: app crash on mac when using ffmpeg or ffprobe

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -42,7 +42,9 @@
                 </svg>
                 Download
             </a>
-            <a class="download-options" href="https://github.com/murgatt/recode-converter/releases/latest">More download options</a>
+            <a class="download-options" href="https://github.com/murgatt/recode-converter/releases/latest"
+                >More download options</a
+            >
             <img src="img/app.png" alt="Recode Converter app" class="app" />
         </main>
         <section>

--- a/docs/index.js
+++ b/docs/index.js
@@ -5,12 +5,12 @@ const PLATFORMS = {
     linux: 'linux',
     mac: 'mac',
     windows: 'win',
-}
+};
 
 const EXTENSIONS = {
     mac: 'dmg',
     win: 'exe',
-}
+};
 
 const getPlatform = () => {
     const userAgent = navigator.userAgent.toLowerCase();
@@ -23,7 +23,9 @@ const getPlatform = () => {
     if (userAgent.match(/linux/)) {
         return PLATFORMS.linux;
     }
-}
+
+    return '';
+};
 
 const getAssetDownloadUrl = assets => {
     const platform = getPlatform();
@@ -39,7 +41,7 @@ const getAssetDownloadUrl = assets => {
     }
 
     return platformAsset.browser_download_url;
-}
+};
 
 const getDownloadUrl = async () => {
     const response = await fetch(GITHUB_API_URL);

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "@testing-library/user-event": "^7.1.2",
         "classnames": "^2.2.6",
         "electron-is-dev": "^1.1.0",
+        "fix-path": "^3.0.0",
         "fluent-ffmpeg": "^2.1.2",
         "i18next": "^19.0.3",
         "lodash-es": "^4.17.15",

--- a/public/electron.js
+++ b/public/electron.js
@@ -1,6 +1,9 @@
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
 const isDev = require('electron-is-dev');
+const fixPath = require('fix-path');
+
+fixPath();
 
 const ConversionManager = require('./conversionManager');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4125,6 +4125,14 @@ cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
+  integrity sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
+  dependencies:
+    lru-cache "^4.0.1"
+    which "^1.2.9"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -4525,6 +4533,11 @@ default-gateway@^4.2.0:
   dependencies:
     execa "^1.0.0"
     ip-regex "^2.1.0"
+
+default-shell@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/default-shell/-/default-shell-1.0.1.tgz#752304bddc6174f49eb29cb988feea0b8813c8bc"
+  integrity sha1-dSMEvdxhdPSespy5iP7qC4gTyLw=
 
 defer-to-connect@^1.0.1:
   version "1.1.3"
@@ -5396,6 +5409,19 @@ exec-sh@^0.3.2:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
   integrity sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==
 
+execa@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.5.1.tgz#de3fb85cb8d6e91c85bcbceb164581785cb57b36"
+  integrity sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=
+  dependencies:
+    cross-spawn "^4.0.0"
+    get-stream "^2.2.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -5761,6 +5787,13 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+fix-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fix-path/-/fix-path-3.0.0.tgz#c6b82fd5f5928e520b392a63565ebfef0ddf037e"
+  integrity sha512-opGAl4+ip5jUikHR2C8Jo7czZ80pz8EK/0gMlAZu7xgDmBqIynlX8SMYg9KowYjAU6HT0nxsSJEWru0u+n+N2Q==
+  dependencies:
+    shell-path "^2.1.0"
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
@@ -5997,6 +6030,14 @@ get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
+
+get-stream@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
+  integrity sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=
+  dependencies:
+    object-assign "^4.0.1"
+    pinkie-promise "^2.0.0"
 
 get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
@@ -11774,6 +11815,22 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shell-env@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/shell-env/-/shell-env-0.3.0.tgz#2250339022989165bda4eb7bf383afeaaa92dc34"
+  integrity sha1-IlAzkCKYkWW9pOt784Ov6qqS3DQ=
+  dependencies:
+    default-shell "^1.0.0"
+    execa "^0.5.0"
+    strip-ansi "^3.0.0"
+
+shell-path@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/shell-path/-/shell-path-2.1.0.tgz#ea7d06ae1070874a1bac5c65bb9bdd62e4f67a38"
+  integrity sha1-6n0GrhBwh0obrFxlu5vdYuT2ejg=
+  dependencies:
+    shell-env "^0.3.0"
 
 shell-quote@1.7.2:
   version "1.7.2"


### PR DESCRIPTION
## Description
On Mac, once the app is packaged, ffmpeg & ffprobe are not found and can't be used (and any other command in the PATH).
Using [fix-path](https://github.com/sindresorhus/fix-path) solved this issue.

https://github.com/electron/electron/issues/7688
https://stackoverflow.com/questions/48420819/cannot-execute-shell-command-from-electron-packaged-app

## How to test
Package the app and try to run it, display file streams info & run a conversion

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the translations
- [ ] I have updated the translation files accordingly
<!---
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
--->
