### PR TITLE
fix(conversion): wrong status if file added during conversion

### DIFF
--- a/src/store/conversion/conversion.actions.js
+++ b/src/store/conversion/conversion.actions.js
@@ -1,6 +1,7 @@
 import { openSnackbar } from '../snackbar/snackbar.actions';
 import { getConversionSettings } from '../conversionSettings/conversionSettings.selectors';
-import { getAreAllFilesComplete, getDestination, getFilesToConvert } from '../file/file.selectors';
+import { getDestination, getFilesToConvert } from '../file/file.selectors';
+import { getConversionList } from './conversion.selectors';
 import i18n from '../../i18n';
 
 const { ipcRenderer } = window.require('electron');
@@ -8,8 +9,28 @@ const { ipcRenderer } = window.require('electron');
 export const PAUSE_CONVERSION = 'conversion/PAUSE_CONVERSION';
 export const START_CONVERSION = 'conversion/START_CONVERSION';
 export const CONVERSION_END = 'conversion/CONVERSION_END';
+export const SET_CONVERSION_LIST = 'conversion/ADD_FILES_TO_CONVERSION_LIST';
+export const CLEAR_CONVERSION_LIST = 'conversion/CLEAR_CONVERSION_LIST';
+
+export const addFilesToConversionList = fileList => dispatch => {
+    const conversionList = fileList.map(file => file.path);
+    dispatch({ conversionList, type: SET_CONVERSION_LIST });
+};
+
+export const clearConversionList = dispatch => dispatch({ type: CLEAR_CONVERSION_LIST });
+
+export const removeFileFromConversionList = filePath => (dispatch, getState) => {
+    const conversionList = getConversionList(getState());
+    const index = conversionList.indexOf(filePath);
+
+    if (index > -1) {
+        conversionList.splice(index, 1);
+        dispatch({ conversionList, type: SET_CONVERSION_LIST });
+    }
+};
 
 export const pauseConversion = dispatch => {
+    dispatch(clearConversionList);
     dispatch({ type: PAUSE_CONVERSION });
     dispatch(openSnackbar(i18n.t('conversion.conversionPauseMessage')));
     ipcRenderer.send('ffmpeg-pause-conversion');
@@ -21,6 +42,7 @@ export const startConversion = (dispatch, getState) => {
     const fileList = getFilesToConvert(getState());
 
     if (fileList.length) {
+        dispatch(addFilesToConversionList(fileList));
         dispatch({ type: START_CONVERSION });
         ipcRenderer.send('ffmpeg-run-conversion', { destination, fileList, options: conversionSettings });
     }
@@ -29,8 +51,8 @@ export const startConversion = (dispatch, getState) => {
 export const endConversion = dispatch => dispatch({ type: CONVERSION_END });
 
 export const checkConversionProgress = (dispatch, getState) => {
-    const areAllFilesComplete = getAreAllFilesComplete(getState());
-    if (areAllFilesComplete) {
+    const conversionList = getConversionList(getState());
+    if (conversionList.length === 0) {
         dispatch(endConversion);
     }
 };

--- a/src/store/conversion/conversion.reducer.js
+++ b/src/store/conversion/conversion.reducer.js
@@ -1,7 +1,14 @@
-import { PAUSE_CONVERSION, START_CONVERSION, CONVERSION_END } from './conversion.actions';
+import {
+    PAUSE_CONVERSION,
+    START_CONVERSION,
+    CONVERSION_END,
+    SET_CONVERSION_LIST,
+    CLEAR_CONVERSION_LIST,
+} from './conversion.actions';
 import { CONVERSION_STATUS } from './conversion.constants';
 
 const initialState = {
+    conversionList: [],
     status: CONVERSION_STATUS.pause,
 };
 
@@ -17,6 +24,16 @@ export default (state = initialState, action) => {
             return {
                 ...state,
                 status: CONVERSION_STATUS.converting,
+            };
+        case SET_CONVERSION_LIST:
+            return {
+                ...state,
+                conversionList: action.conversionList,
+            };
+        case CLEAR_CONVERSION_LIST:
+            return {
+                ...state,
+                conversionList: [],
             };
         default:
             return state;

--- a/src/store/conversion/conversion.selectors.js
+++ b/src/store/conversion/conversion.selectors.js
@@ -1,5 +1,4 @@
-/* eslint-disable import/prefer-default-export */
-
 import { CONVERSION_STATUS } from './conversion.constants';
 
 export const getIsConversionRunning = ({ conversion }) => conversion.status === CONVERSION_STATUS.converting;
+export const getConversionList = ({ conversion }) => conversion.conversionList;

--- a/src/store/file/file.actions.js
+++ b/src/store/file/file.actions.js
@@ -1,7 +1,7 @@
 import { areFilesFromSameDirectory, getDirPathFromFilePath, normalizeFiles } from './file.utils';
 import { FILE_STATUS } from './file.constants';
 import { getFilesById, getIsDestinationManuallySet } from './file.selectors';
-import { checkConversionProgress } from '../conversion/conversion.actions';
+import { checkConversionProgress, removeFileFromConversionList } from '../conversion/conversion.actions';
 import i18n from '../../i18n';
 
 const { ipcRenderer } = window.require('electron');
@@ -65,6 +65,7 @@ export const setFileConversionEnd = fileId => async (dispatch, getState) => {
         progress: 100,
         status: FILE_STATUS.complete,
     };
+    dispatch(removeFileFromConversionList(fileId));
     dispatch({ files: file, type: UPDATE_FILES });
     dispatch(checkConversionProgress);
 };
@@ -75,6 +76,7 @@ export const setFileConversionError = fileId => (dispatch, getState) => {
         ...filesById[fileId],
         status: FILE_STATUS.error,
     };
+    dispatch(removeFileFromConversionList(fileId));
     dispatch({ files: file, type: UPDATE_FILES });
     dispatch(checkConversionProgress);
 };

--- a/src/store/file/file.selectors.js
+++ b/src/store/file/file.selectors.js
@@ -1,11 +1,5 @@
-import _ from 'lodash-es';
 import { FILE_STATUS } from './file.constants';
 
-export const getAreAllFilesComplete = ({ file: { filesById } }) =>
-    _.every(
-        filesById,
-        fileObject => fileObject.status === FILE_STATUS.complete || fileObject.status === FILE_STATUS.error,
-    );
 export const getDestination = ({ file: { destination } }) => destination;
 export const getFileIds = ({ file: { fileIds } }) => fileIds;
 export const getFilesById = ({ file: { filesById } }) => filesById;


### PR DESCRIPTION
Related issue #45 

## Description
If a file was added during a conversion, at the end of the conversion, the status is still `converting`.
What was done:
- add a dynamic conversion list at the start of the conversion
- remove file from conversion list when this has been converted
- improve the conversion progress check based  on the conversion list

## How to test
- run the app & add a file to convert
- start the conversion and add a file before the end
- at the end of the conversion it should really and the start/pause button should be "start"

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the translations
- [ ] I have updated the translation files accordingly
<!---
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
--->
