### PR TITLE
build(dependencies): move testing library to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "dependencies": {
         "@material-ui/core": "^4.9.13",
         "@material-ui/icons": "^4.9.1",
-        "@testing-library/jest-dom": "^4.2.4",
-        "@testing-library/react": "^9.3.2",
-        "@testing-library/user-event": "^7.1.2",
         "classnames": "^2.2.6",
         "electron-is-dev": "^1.1.0",
         "fix-path": "^3.0.0",
@@ -59,6 +56,9 @@
         "typeface-roboto": "^0.0.75"
     },
     "devDependencies": {
+        "@testing-library/jest-dom": "^4.2.4",
+        "@testing-library/react": "^9.3.2",
+        "@testing-library/user-event": "^7.1.2",
         "concurrently": "^5.1.0",
         "conventional-github-releaser": "^3.1.3",
         "electron": "^9.1.1",


### PR DESCRIPTION
## Description
I moved the dependencies related to testing-library to dev dependencies.
This is the right thing to do according the documentation : 
https://testing-library.com/docs/react-testing-library/intro

## How to test
The application should still bundle after a clean install and the tests should also pass.

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the translations
- [ ] I have updated the translation files accordingly
<!---
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
--->
