### PR TITLE
fix: conversion error when destination is 'Same as source'

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-Related issue # (if appropriate)
-
 ## Description
 
 ## How to test

--- a/src/store/conversion/conversion.actions.js
+++ b/src/store/conversion/conversion.actions.js
@@ -38,7 +38,8 @@ export const pauseConversion = dispatch => {
 
 export const startConversion = (dispatch, getState) => {
     const conversionSettings = getConversionSettings(getState());
-    const destination = getDestination(getState());
+    const selectedDestination = getDestination(getState());
+    const destination = selectedDestination === i18n.t('global.sameAsSource') ? '' : selectedDestination;
     const fileList = getFilesToConvert(getState());
 
     if (fileList.length) {


### PR DESCRIPTION
Fixes #63 

## Description
When multiple files are added from different directories and the destination is not manually set a conversion error occurred due to wrong destination.
In this case the destination is set to "Same as source" and passed in the conversion options.

In this case, we now pass an empty destination, this way the destination is automatically set as the converted file directory during the conversion.

## How to test
Add at least two files from different directory
Do not set a destination
Start the conversion

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the translations
- [ ] I have updated the translation files accordingly
<!---
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
---> 