### PR TITLE
feat: add front side console error when conversion fails

### DIFF
--- a/public/conversionManager.js
+++ b/public/conversionManager.js
@@ -10,7 +10,7 @@ class ConversionManager {
         this.conversionIsInterrupted = false;
         this.callbacks = {
             onConversionEnd: file => this.fileConversionEnd(file),
-            onConversionError: file => this.fileConversionError(file),
+            onConversionError: (file, err, stdout, stderr) => this.fileConversionError(file, err, stdout, stderr),
             onConversionProgress: (file, progress) => this.fileConversionProgress(file, progress),
             onConversionStart: file => this.fileConversionStart(file),
         };
@@ -38,8 +38,8 @@ class ConversionManager {
         this.window.send('file-conversion-end', { filePath });
     }
 
-    fileConversionError(filePath) {
-        this.window.send('file-conversion-error', { filePath });
+    fileConversionError(filePath, err, stdout, stderr) {
+        this.window.send('file-conversion-error', { filePath, err, stderr, stdout });
     }
 
     fileConversionProgress(filePath, progress) {

--- a/public/ffmpeg.js
+++ b/public/ffmpeg.js
@@ -92,7 +92,7 @@ const convert = ({ file, options = {}, callbacks = {}, destination }) => {
             })
             .on('error', (err, stdout, stderr) => {
                 console.log(err, stdout, stderr);
-                onConversionError(inputPath);
+                onConversionError(inputPath, err, stdout, stderr);
                 reject(err);
             })
             .on('end', (stdout, stderr) => {

--- a/src/registerElectronEvents.js
+++ b/src/registerElectronEvents.js
@@ -18,8 +18,10 @@ ipcRenderer.on('file-conversion-end', (event, data) => {
 });
 
 ipcRenderer.on('file-conversion-error', (event, data) => {
-    const { filePath } = data;
+    const { filePath, err, stderr, stdout } = data;
     store.dispatch(setFileConversionError(filePath));
+    // eslint-disable-next-line no-console
+    console.error(`Conversion error for file ${filePath}`, err, stderr, stdout);
 });
 
 ipcRenderer.on('file-conversion-progress', (event, data) => {


### PR DESCRIPTION
## Description
When a conversion error occurred there is no way to see the details of what happened.
This PR add a console error on the front side to display the server side error.

## How to test
Do something wrong to trigger an error during conversion
Start the conversion and open the development console to see the error

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the translations
- [ ] I have updated the translation files accordingly
<!---
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
--->
