### PR TITLE
fix(v2): typescript errors when importing shared files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,1 @@
 dist-electron
-
-# TODO temp fix for eslint/ts error
-electron/convert/index.ts
-electron/convert/convert.utils.ts
-schema/index.ts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Tests
         run: pnpm run test
 
+      - name: Types
+        run: pnpm run types
+
       - name: Pull Request title
         if: github.event_name == 'pull_request'
         uses: amannn/action-semantic-pull-request@v5

--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -6,13 +6,6 @@ import type {
 } from './conversion-events.types';
 import type { ConversionSettings, VideoFile } from '../schema';
 
-declare namespace NodeJS {
-  interface ProcessEnv {
-    DIST: string;
-    VITE_PUBLIC: string;
-  }
-}
-
 export interface IDialog {
   openDirectory: () => Promise<string>;
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,8 +3,8 @@ import { app, BrowserWindow, ipcMain } from 'electron';
 import { ConversionManager } from './ConversionManager';
 import { handleOpenDirectory } from './dialog';
 
-process.env.DIST = path.join(__dirname, '../dist');
-process.env.VITE_PUBLIC = app.isPackaged ? process.env.DIST : path.join(process.env.DIST, '../public');
+const DIST = path.join(__dirname, '../dist');
+const VITE_PUBLIC = app.isPackaged ? DIST : path.join(DIST, '../public');
 
 // 🚧 Use ['ENV_NAME'] avoid vite:define plugin - Vite@2.x
 const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL'];
@@ -13,7 +13,7 @@ let conversionManager: ConversionManager;
 
 function createWindow() {
   const mainWindow = new BrowserWindow({
-    icon: path.join(process.env.VITE_PUBLIC, 'electron-vite.svg'),
+    icon: path.join(VITE_PUBLIC, 'electron-vite.svg'),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
     },
@@ -22,7 +22,7 @@ function createWindow() {
   if (VITE_DEV_SERVER_URL) {
     mainWindow.loadURL(VITE_DEV_SERVER_URL);
   } else {
-    mainWindow.loadFile(path.join(process.env.DIST, 'index.html'));
+    mainWindow.loadFile(path.join(DIST, 'index.html'));
   }
 
   if (conversionManager) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "prettier": "prettier . --check --config .prettierrc",
     "prettier:fix": "prettier . --write --config .prettierrc",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "types": "tsc"
   },
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "1.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,5 +33,5 @@
     "postcss.config.js",
     "tailwind.config.js"
   ],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "extends": "./tsconfig.node.json"
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Description
- remove `composite` property from `tsconfig.node.json` (fix locales json import)
- change `references` to `extends` in `tsconfig.json`
- add `types` script in `package.json` and `Types` job to check type errors in CI
- temp ignored files in `.eslintignore` are no longer useful
- `DIST` & `VITE_PUBLIC` are now constants instead of env variables

