### PR TITLE
feat(v2): disable states during conversion

### DIFF
--- a/electron/ConversionManager.ts
+++ b/electron/ConversionManager.ts
@@ -45,6 +45,7 @@ export class ConversionManager {
             console.error(error);
           }
         }
+        this.mainWindow.webContents.send('conversion-end');
       },
     );
 

--- a/electron/conversion-events.types.ts
+++ b/electron/conversion-events.types.ts
@@ -1,6 +1,8 @@
 import type { IpcRendererEvent } from 'electron';
 import type { FfprobeData } from 'fluent-ffmpeg';
 
+export type ConversionEndCallback = (event: IpcRendererEvent) => void;
+
 export type FileConversionStartCallback = (event: IpcRendererEvent, { filePath }: { filePath: string }) => void;
 
 export type FileConversionProgressCallback = (

--- a/electron/convert/convert.ts
+++ b/electron/convert/convert.ts
@@ -1,6 +1,7 @@
 /// <reference types="fluent-ffmpeg" />
 import { getIgnoredStreamsOptions, getOutputOptions, getOutputPath, getStreamsTitleOptions } from './convert.utils';
 import type { ConversionSettings, VideoFile } from '../../schema';
+import type { ProgressInfo } from 'electron-builder';
 
 const ffmpegPath = require('@ffmpeg-installer/ffmpeg').path;
 const ffmpeg = require('fluent-ffmpeg');
@@ -44,7 +45,7 @@ export function convert(
         console.log(commandLine);
         onFileConversionStart(inputPath, commandLine);
       })
-      .on('progress', ({ percent }: { percent?: number }) => {
+      .on('progress', ({ percent }: ProgressInfo) => {
         onFileConversionProgress(inputPath, percent ?? 0);
       })
       .on('end', () => {

--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -1,4 +1,5 @@
 import type {
+  ConversionEndCallback,
   FileConversionEndCallback,
   FileConversionErrorCallback,
   FileConversionProgressCallback,
@@ -13,6 +14,7 @@ export interface IDialog {
 
 export interface IConversion {
   getMetadata: ({ filePath }: { filePath: string }) => void;
+  onConversionEnd: (callback: ConversionEndCallback) => void;
   onFileConversionEnd: (callback: FileConversionEndCallback) => void;
   onFileConversionError: (callback: FileConversionErrorCallback) => void;
   onFileConversionProgress: (callback: FileConversionProgressCallback) => void;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld('dialog', {
 
 contextBridge.exposeInMainWorld('conversion', {
   getMetadata: ({ filePath }) => ipcRenderer.invoke('get-metadata', { filePath }),
+  onConversionEnd: callback => ipcRenderer.on('conversion-end', callback),
   onFileConversionEnd: callback => ipcRenderer.on('file-conversion-end', callback),
   onFileConversionError: callback => ipcRenderer.on('file-conversion-error', callback),
   onFileConversionProgress: callback => ipcRenderer.on('file-conversion-progress', callback),

--- a/src/components/ConversionSettingsForm/BitrateSelect.tsx
+++ b/src/components/ConversionSettingsForm/BitrateSelect.tsx
@@ -6,6 +6,7 @@ import type { Bitrate, Codec } from 'schema';
 
 type BitrateSelectProps = {
   codec: Codec;
+  isDisabled: boolean;
   onChange: (value: Bitrate) => void;
   value: Bitrate;
 };
@@ -17,15 +18,15 @@ const bitrateByCodec: Record<Codec, Bitrate[]> = {
   eac3: ['default', '192k', '320k', '448k', '640k', '1024k', '2048k', '4096k'],
 };
 
-export const BitrateSelect = ({ codec, value, onChange }: BitrateSelectProps) => {
+export const BitrateSelect = ({ codec, isDisabled, value, onChange }: BitrateSelectProps) => {
   const { t } = useTranslation();
   const options = bitrateByCodec[codec];
-  const isDisabled = codec === codecSchema.enum.default;
+  const disabled = codec === codecSchema.enum.default || isDisabled;
 
   return (
     <FormItem>
       <FormLabel>{t('conversionSettings.bitrate.label')}</FormLabel>
-      <Select disabled={isDisabled} onValueChange={onChange} value={value}>
+      <Select disabled={disabled} onValueChange={onChange} value={value}>
         <FormControl>
           <SelectTrigger>
             <SelectValue />

--- a/src/components/ConversionSettingsForm/ChannelsSelect.tsx
+++ b/src/components/ConversionSettingsForm/ChannelsSelect.tsx
@@ -6,6 +6,7 @@ import type { Channels, Codec } from 'schema';
 
 type ChannelsSelectProps = {
   codec: Codec;
+  isDisabled: boolean;
   onChange: (value: Channels) => void;
   value: Channels;
 };
@@ -17,15 +18,15 @@ const channelsByCodec: Record<Codec, Channels[]> = {
   eac3: ['default', '1', '2', '3', '4', '5', '6'],
 };
 
-export const ChannelsSelect = ({ codec, onChange, value }: ChannelsSelectProps) => {
+export const ChannelsSelect = ({ isDisabled, codec, onChange, value }: ChannelsSelectProps) => {
   const { t } = useTranslation();
   const options = channelsByCodec[codec];
-  const isDisabled = codec === codecSchema.enum.default;
+  const disabled = codec === codecSchema.enum.default || isDisabled;
 
   return (
     <FormItem>
       <FormLabel>{t('conversionSettings.channels.label')}</FormLabel>
-      <Select disabled={isDisabled} onValueChange={onChange} value={value}>
+      <Select disabled={disabled} onValueChange={onChange} value={value}>
         <FormControl>
           <SelectTrigger>
             <SelectValue />

--- a/src/components/ConversionSettingsForm/CodecSelect.tsx
+++ b/src/components/ConversionSettingsForm/CodecSelect.tsx
@@ -5,18 +5,19 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import type { Codec } from 'schema';
 
 type CodecSelectProps = {
+  isDisabled: boolean;
   onChange: (value: Codec) => void;
   value: Codec;
 };
 
-export const CodecSelect = ({ onChange, value }: CodecSelectProps) => {
+export const CodecSelect = ({ isDisabled, onChange, value }: CodecSelectProps) => {
   const { t } = useTranslation();
   const options = codecSchema.options.map(option => option);
 
   return (
     <FormItem>
       <FormLabel>{t('conversionSettings.codec.label')}</FormLabel>
-      <Select onValueChange={onChange} value={value}>
+      <Select disabled={isDisabled} onValueChange={onChange} value={value}>
         <FormControl>
           <SelectTrigger>
             <SelectValue />

--- a/src/components/ConversionSettingsForm/ConversionSettingsForm.tsx
+++ b/src/components/ConversionSettingsForm/ConversionSettingsForm.tsx
@@ -10,10 +10,11 @@ import { SampleRateSelect } from './SampleRateSelect';
 import type { ConversionSettings } from 'schema';
 
 type ConversionSettingsFormProps = {
+  isDisabled: boolean;
   onStartConversion: (conversionSettings: ConversionSettings) => void;
 };
 
-export const ConversionSettingsForm = ({ onStartConversion }: ConversionSettingsFormProps) => {
+export const ConversionSettingsForm = ({ isDisabled, onStartConversion }: ConversionSettingsFormProps) => {
   const { t } = useTranslation();
   const form = useConversionSettingsForm({
     defaultValues: {
@@ -39,22 +40,28 @@ export const ConversionSettingsForm = ({ onStartConversion }: ConversionSettings
         <FormField
           control={control}
           name="codec"
-          render={({ field }) => <CodecSelect onChange={field.onChange} value={field.value} />}
+          render={({ field }) => <CodecSelect isDisabled={isDisabled} onChange={field.onChange} value={field.value} />}
         />
         <FormField
           control={control}
           name="bitrate"
-          render={({ field }) => <BitrateSelect codec={codec} onChange={field.onChange} value={field.value} />}
+          render={({ field }) => (
+            <BitrateSelect codec={codec} isDisabled={isDisabled} onChange={field.onChange} value={field.value} />
+          )}
         />
         <FormField
           control={control}
           name="sampleRate"
-          render={({ field }) => <SampleRateSelect codec={codec} onChange={field.onChange} value={field.value} />}
+          render={({ field }) => (
+            <SampleRateSelect codec={codec} isDisabled={isDisabled} onChange={field.onChange} value={field.value} />
+          )}
         />
         <FormField
           control={control}
           name="channels"
-          render={({ field }) => <ChannelsSelect codec={codec} onChange={field.onChange} value={field.value} />}
+          render={({ field }) => (
+            <ChannelsSelect codec={codec} isDisabled={isDisabled} onChange={field.onChange} value={field.value} />
+          )}
         />
       </form>
     </Form>

--- a/src/components/ConversionSettingsForm/SampleRateSelect.tsx
+++ b/src/components/ConversionSettingsForm/SampleRateSelect.tsx
@@ -6,6 +6,7 @@ import type { Codec, SampleRate } from 'schema';
 
 type SampleRateSelectProps = {
   codec: Codec;
+  isDisabled: boolean;
   onChange: (value: SampleRate) => void;
   value: SampleRate;
 };
@@ -17,15 +18,15 @@ const sampleRateByCodec: Record<Codec, SampleRate[]> = {
   eac3: ['default', '32000', '44100', '48000'],
 };
 
-export const SampleRateSelect = ({ codec, onChange, value }: SampleRateSelectProps) => {
+export const SampleRateSelect = ({ codec, isDisabled, onChange, value }: SampleRateSelectProps) => {
   const { t } = useTranslation();
   const options = sampleRateByCodec[codec];
-  const isDisabled = codec === codecSchema.enum.default;
+  const disabled = codec === codecSchema.enum.default || isDisabled;
 
   return (
     <FormItem>
       <FormLabel>{t('conversionSettings.sampleRate.label')}</FormLabel>
-      <Select disabled={isDisabled} onValueChange={onChange} value={value}>
+      <Select disabled={disabled} onValueChange={onChange} value={value}>
         <FormControl>
           <SelectTrigger>
             <SelectValue />

--- a/src/components/FileCard/FileCard.tsx
+++ b/src/components/FileCard/FileCard.tsx
@@ -15,16 +15,20 @@ import type { VideoFile } from 'schema';
 
 type FileCardProps = {
   file: VideoFile;
+  isConversionRunning: boolean;
 };
 
-export const FileCard = ({ file }: FileCardProps) => {
+export const FileCard = ({ file, isConversionRunning }: FileCardProps) => {
   const { t } = useTranslation();
   const [isStreamTableOpen, setIsStreamTableOpen] = useState(false);
   const toggleStreamTableLabel = isStreamTableOpen ? t('fileList.file.hideStreams') : t('fileList.file.displayStreams');
 
   const { metadata, name, path, progress, size, status, streamsTitle, streamsToCopy } = file;
   const formattedFileSize = formatFileSize(size);
+
   const isProgressDisplayed = status === fileStatusSchema.enum.converting && progress > 0;
+  const isRemoveButtonDisabled = isConversionRunning || status === fileStatusSchema.enum.converting;
+  const isStreamEditDisabled = isConversionRunning || status !== fileStatusSchema.enum.imported;
 
   const removeFile = useStore(state => state.removeFile);
   const setStreamsToCopy = useStore(state => state.setStreamsToCopy);
@@ -52,6 +56,7 @@ export const FileCard = ({ file }: FileCardProps) => {
           <Button
             aria-label={t('fileList.file.remove')}
             className="shrink-0"
+            disabled={isRemoveButtonDisabled}
             onClick={() => removeFile(path)}
             size="icon"
             variant="outline"
@@ -73,6 +78,7 @@ export const FileCard = ({ file }: FileCardProps) => {
         <CollapsibleContent>
           {metadata && (
             <StreamTable
+              isStreamEditDisabled={isStreamEditDisabled}
               onStreamCheckedChange={handleStreamCheckedChange}
               onStreamTitleChange={handleStreamTitleChange}
               streams={metadata.streams}

--- a/src/components/FileCard/__tests__/FileCard.test.tsx
+++ b/src/components/FileCard/__tests__/FileCard.test.tsx
@@ -14,28 +14,41 @@ const defaultFile = {
 
 describe('FileCard', () => {
   it('should not display a progress bar if file is not converting', () => {
-    render(<FileCard file={defaultFile} />);
+    render(<FileCard file={defaultFile} isConversionRunning={false} />);
 
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
-  it('should not display a progress bar if file is converting but progress is 0', () => {
+  it('should not display a progress bar if file is being converted but progress is 0', () => {
     const file = { ...defaultFile, status: fileStatusSchema.enum.converting };
-    render(<FileCard file={file} />);
+    render(<FileCard file={file} isConversionRunning />);
 
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
-  it('should display a progress bar if file is converting but progress is more than 0', () => {
+  it('should display a progress bar if file is being converted but progress is more than 0', () => {
     const file = { ...defaultFile, progress: 50, status: fileStatusSchema.enum.converting };
-    render(<FileCard file={file} />);
+    render(<FileCard file={file} isConversionRunning />);
 
     expect(screen.getByRole('progressbar')).toBeVisible();
   });
 
   it('should display closed collapsible metadata by default', () => {
-    render(<FileCard file={defaultFile} />);
+    render(<FileCard file={defaultFile} isConversionRunning={false} />);
 
     expect(screen.getByRole('button', { name: 'Display stream list' })).toBeVisible();
+  });
+
+  it('should display a disabled remove button if conversion is running', () => {
+    render(<FileCard file={defaultFile} isConversionRunning />);
+
+    expect(screen.getByRole('button', { name: 'Remove file' })).toBeDisabled();
+  });
+
+  it('should display a disabled remove button if conversion is not running but file is still being converted', () => {
+    const file = { ...defaultFile, status: fileStatusSchema.enum.converting };
+    render(<FileCard file={file} isConversionRunning={false} />);
+
+    expect(screen.getByRole('button', { name: 'Remove file' })).toBeDisabled();
   });
 });

--- a/src/components/FileImport.tsx
+++ b/src/components/FileImport.tsx
@@ -7,10 +7,11 @@ import { Button } from './ui/Button';
 
 type FileImportProps = {
   children: React.ReactNode;
+  isDisabled: boolean;
   isFileListDisplayed: boolean;
 };
 
-export const FileImport = ({ children, isFileListDisplayed }: FileImportProps) => {
+export const FileImport = ({ children, isDisabled, isFileListDisplayed }: FileImportProps) => {
   const { t } = useTranslation();
   const addFiles = useStore(state => state.addFiles);
 
@@ -22,6 +23,7 @@ export const FileImport = ({ children, isFileListDisplayed }: FileImportProps) =
     accept: {
       'video/*': ['.mkv'],
     },
+    disabled: isDisabled,
     noClick: true,
     onDropAccepted: handleFilesDrop,
   });

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -1,6 +1,7 @@
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { ListXIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { fileStatusSchema } from 'schema';
 import { useStore } from 'src/store';
 import { FileCard } from './FileCard';
 import { Button } from './ui/Button';
@@ -9,19 +10,22 @@ import type { VideoFile } from 'schema';
 
 type FileListProps = {
   files: VideoFile[];
+  isConversionRunning: boolean;
 };
 
-export const FileList = ({ files }: FileListProps) => {
+export const FileList = ({ files, isConversionRunning }: FileListProps) => {
   const { t } = useTranslation();
   const clearFiles = useStore(state => state.clearFiles);
   const [listRef] = useAutoAnimate();
+  const isFileConversionRunning = files.some(file => file.status === fileStatusSchema.enum.converting);
+  const isClearButtonDisabled = isConversionRunning || isFileConversionRunning;
 
   return (
     <div className="relative h-full">
       <ul className="flex h-full flex-col gap-3 overflow-y-auto px-4 pb-14 pt-4" ref={listRef}>
         {files.map(file => (
           <li key={file.path}>
-            <FileCard file={file} />
+            <FileCard file={file} isConversionRunning={isConversionRunning} />
           </li>
         ))}
       </ul>
@@ -29,6 +33,7 @@ export const FileList = ({ files }: FileListProps) => {
         <Button
           aria-label={t('fileList.clear')}
           className="absolute inset-x-0 bottom-2 mx-auto"
+          disabled={isClearButtonDisabled}
           onClick={clearFiles}
           size="icon"
           variant="ghost"

--- a/src/components/Footer/DestinationInput.tsx
+++ b/src/components/Footer/DestinationInput.tsx
@@ -7,7 +7,11 @@ import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
 import { Tooltip } from '../ui/Tooltip';
 
-export const DestinationInput = () => {
+type DestinationInputProps = {
+  isDisabled: boolean;
+};
+
+export const DestinationInput = ({ isDisabled }: DestinationInputProps) => {
   const { t } = useTranslation();
   const files = useStore(getFiles);
   const destinationPath = useStore(getDestinationPath);
@@ -34,7 +38,13 @@ export const DestinationInput = () => {
     <div className="flex w-1/2 gap-2">
       <Input disabled placeholder={t('footer.destination')} value={displayedDestinationPath} />
       <Tooltip content={t('footer.selectDestination')}>
-        <Button aria-label={t('footer.selectDestination')} onClick={handleOpenDirectory} size="icon" variant="ghost">
+        <Button
+          aria-label={t('footer.selectDestination')}
+          disabled={isDisabled}
+          onClick={handleOpenDirectory}
+          size="icon"
+          variant="ghost"
+        >
           <FolderIcon size="16" />
         </Button>
       </Tooltip>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,6 +1,7 @@
-import { PlayIcon, StopCircleIcon } from 'lucide-react';
+import { PauseIcon, PlayIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '../ui/Button';
+import { Tooltip } from '../ui/Tooltip';
 import { DestinationInput } from './DestinationInput';
 
 type FooterProps = {
@@ -14,12 +15,14 @@ export const Footer = ({ isConversionRunning, isStartButtonDisabled, onStopConve
 
   return (
     <footer className="flex shrink-0 justify-between border-t p-4">
-      <DestinationInput />
+      <DestinationInput isDisabled={isConversionRunning} />
       {isConversionRunning ? (
-        <Button onClick={onStopConversion}>
-          <StopCircleIcon size="16" />
-          {t('footer.stopConversion')}
-        </Button>
+        <Tooltip content={t('footer.stopConversionTooltip')} delayDuration={0}>
+          <Button onClick={onStopConversion}>
+            <PauseIcon size="16" />
+            {t('footer.stopConversion')}
+          </Button>
+        </Tooltip>
       ) : (
         <Button disabled={isStartButtonDisabled} form="conversionSettingsForm" type="submit">
           <PlayIcon size="16" />

--- a/src/components/Footer/__tests__/DestinationInput.test.tsx
+++ b/src/components/Footer/__tests__/DestinationInput.test.tsx
@@ -16,14 +16,14 @@ describe('DestinationInput', () => {
   });
 
   it('should display placeholder by default', () => {
-    render(<DestinationInput />);
+    render(<DestinationInput isDisabled={false} />);
 
     expect(screen.getByPlaceholderText('Destination')).toHaveValue('');
   });
 
   it('should display destination if defined', () => {
     vi.mocked(getDestinationPath).mockReturnValue('/movies');
-    render(<DestinationInput />);
+    render(<DestinationInput isDisabled={false} />);
 
     expect(screen.getByPlaceholderText('Destination')).toHaveValue('/movies');
   });
@@ -32,7 +32,7 @@ describe('DestinationInput', () => {
     const file1 = { path: '/movies/matrix.mkv' } as VideoFile;
     const file2 = { path: '/movies/shining.mkv' } as VideoFile;
     vi.mocked(getFiles).mockReturnValue([file1, file2]);
-    render(<DestinationInput />);
+    render(<DestinationInput isDisabled={false} />);
 
     expect(screen.getByPlaceholderText('Destination')).toHaveValue('/movies');
   });
@@ -41,8 +41,14 @@ describe('DestinationInput', () => {
     const file1 = { path: '/medias/matrix.mkv' } as VideoFile;
     const file2 = { path: '/movies/shining.mkv' } as VideoFile;
     vi.mocked(getFiles).mockReturnValue([file1, file2]);
-    render(<DestinationInput />);
+    render(<DestinationInput isDisabled={false} />);
 
     expect(screen.getByPlaceholderText('Destination')).toHaveValue('Destination same as source');
+  });
+
+  it('should display a disabled button', () => {
+    render(<DestinationInput isDisabled />);
+
+    expect(screen.getByRole('button', { name: 'Select destination' })).toBeDisabled();
   });
 });

--- a/src/components/StreamTable/StreamTable.tsx
+++ b/src/components/StreamTable/StreamTable.tsx
@@ -5,6 +5,7 @@ import type { FfprobeStream } from 'fluent-ffmpeg';
 import type { StreamsTitle, StreamsToCopy } from 'schema';
 
 type StreamTableProps = {
+  isStreamEditDisabled: boolean;
   onStreamCheckedChange: (streamIndex: number, checked: boolean) => void;
   onStreamTitleChange: (streamIndex: number, title: string) => void;
   streams: FfprobeStream[];
@@ -13,6 +14,7 @@ type StreamTableProps = {
 };
 
 export const StreamTable = ({
+  isStreamEditDisabled,
   onStreamCheckedChange,
   onStreamTitleChange,
   streams,
@@ -45,6 +47,7 @@ export const StreamTable = ({
         {streams.map(stream => (
           <StreamTableRow
             checked={streamsToCopy[stream.index]}
+            isDisabled={isStreamEditDisabled}
             key={stream.index}
             onCheckedChange={handleStreamCheckedChange(stream.index)}
             onTitleChange={handleStreamTitleChange(stream.index)}

--- a/src/components/StreamTable/StreamTableRow.tsx
+++ b/src/components/StreamTable/StreamTableRow.tsx
@@ -10,13 +10,21 @@ import type { ChangeEvent } from 'react';
 
 type StreamTableRowProps = {
   checked?: boolean;
+  isDisabled: boolean;
   onCheckedChange: (checked: boolean) => void;
   onTitleChange: (title: string) => void;
   stream: FfprobeStream;
   title?: string;
 };
 
-export const StreamTableRow = ({ checked, onCheckedChange, onTitleChange, stream, title }: StreamTableRowProps) => {
+export const StreamTableRow = ({
+  checked,
+  isDisabled,
+  onCheckedChange,
+  onTitleChange,
+  stream,
+  title,
+}: StreamTableRowProps) => {
   const { t } = useTranslation();
   const { codec_name, codec_type, tags } = stream;
   const isChecked = checked ?? true;
@@ -32,7 +40,7 @@ export const StreamTableRow = ({ checked, onCheckedChange, onTitleChange, stream
       <TableCell className="font-medium">
         <Tooltip content={t('streams.checkboxTooltip')}>
           <div>
-            <Checkbox checked={isChecked} onCheckedChange={onCheckedChange} />
+            <Checkbox checked={isChecked} disabled={isDisabled} onCheckedChange={onCheckedChange} />
           </div>
         </Tooltip>
       </TableCell>
@@ -42,7 +50,7 @@ export const StreamTableRow = ({ checked, onCheckedChange, onTitleChange, stream
       </TableCell>
       <TableCell>{tags.language}</TableCell>
       <TableCell>
-        <Input onChange={handleTitleChange} value={displayedTitle} />
+        <Input disabled={isDisabled} onChange={handleTitleChange} value={displayedTitle} />
       </TableCell>
       <TableCell>
         <StreamTablePropertiesCell stream={stream} />

--- a/src/components/StreamTable/__tests__/StreamTableRow.test.tsx
+++ b/src/components/StreamTable/__tests__/StreamTableRow.test.tsx
@@ -16,7 +16,7 @@ const stream = {
 
 describe('StreamTableRow', () => {
   it('should display default title and checked checkbox by default', () => {
-    render(<StreamTableRow onCheckedChange={vi.fn()} onTitleChange={vi.fn()} stream={stream} />);
+    render(<StreamTableRow isDisabled={false} onCheckedChange={vi.fn()} onTitleChange={vi.fn()} stream={stream} />);
 
     expect(screen.getByRole('checkbox')).toBeChecked();
     expect(screen.getByRole('textbox')).toHaveValue('English');
@@ -24,7 +24,14 @@ describe('StreamTableRow', () => {
 
   it('should display custom title and checked if defined', () => {
     render(
-      <StreamTableRow checked={false} onCheckedChange={vi.fn()} onTitleChange={vi.fn()} stream={stream} title="ENG" />,
+      <StreamTableRow
+        checked={false}
+        isDisabled={false}
+        onCheckedChange={vi.fn()}
+        onTitleChange={vi.fn()}
+        stream={stream}
+        title="ENG"
+      />,
     );
 
     expect(screen.getByRole('checkbox')).not.toBeChecked();
@@ -33,7 +40,9 @@ describe('StreamTableRow', () => {
 
   it('should call onCheckedChange when checkbox is clicked', async () => {
     const onCheckedChange = vi.fn();
-    render(<StreamTableRow onCheckedChange={onCheckedChange} onTitleChange={vi.fn()} stream={stream} />);
+    render(
+      <StreamTableRow isDisabled={false} onCheckedChange={onCheckedChange} onTitleChange={vi.fn()} stream={stream} />,
+    );
 
     await userEvent.click(screen.getByRole('checkbox'));
 
@@ -42,10 +51,19 @@ describe('StreamTableRow', () => {
 
   it('should call onTitleChange when title input change', async () => {
     const onTitleChange = vi.fn();
-    render(<StreamTableRow onCheckedChange={vi.fn()} onTitleChange={onTitleChange} stream={stream} />);
+    render(
+      <StreamTableRow isDisabled={false} onCheckedChange={vi.fn()} onTitleChange={onTitleChange} stream={stream} />,
+    );
 
     await userEvent.type(screen.getByRole('textbox'), '_');
 
     expect(onTitleChange).toHaveBeenCalledWith('English_');
+  });
+
+  it('should display a disabled checkbox and a disable title input', () => {
+    render(<StreamTableRow isDisabled onCheckedChange={vi.fn()} onTitleChange={vi.fn()} stream={stream} />);
+
+    expect(screen.getByRole('checkbox')).toBeDisabled();
+    expect(screen.getByRole('textbox')).toBeDisabled();
   });
 });

--- a/src/components/__tests__/FileImport.test.tsx
+++ b/src/components/__tests__/FileImport.test.tsx
@@ -4,14 +4,22 @@ import { FileImport } from '../FileImport';
 
 describe('FileImport', () => {
   it('should display an import button by default', () => {
-    render(<FileImport isFileListDisplayed={false}>FileList</FileImport>);
+    render(
+      <FileImport isDisabled={false} isFileListDisplayed={false}>
+        FileList
+      </FileImport>,
+    );
 
     expect(screen.getByText('Add files')).toBeVisible();
     expect(screen.queryByText('FileList')).not.toBeInTheDocument();
   });
 
   it('should display file list instead of import button if files have been added', () => {
-    render(<FileImport isFileListDisplayed>FileList</FileImport>);
+    render(
+      <FileImport isDisabled={false} isFileListDisplayed>
+        FileList
+      </FileImport>,
+    );
 
     expect(screen.getByText('FileList')).toBeVisible();
     expect(screen.queryByText('Add files')).not.toBeInTheDocument();

--- a/src/components/__tests__/FileList.test.tsx
+++ b/src/components/__tests__/FileList.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { fileStatusSchema } from 'schema';
 import { describe, expect, it, vi } from 'vitest';
 import { FileList } from '../FileList';
 import type { VideoFile } from 'schema';
@@ -14,8 +15,22 @@ const file3 = { name: 'file3.mkv', path: '/path/file3.mkv', size: 1024 } as Vide
 describe('FileList', () => {
   it('should display a list of file', () => {
     const files = [file1, file2, file3];
-    render(<FileList files={files} />);
+    render(<FileList files={files} isConversionRunning={false} />);
 
     expect(screen.queryAllByRole('listitem').length).toBe(3);
+  });
+
+  it('should display a disabled remove all files button if conversion is running', () => {
+    const files = [file1, file2, file3];
+    render(<FileList files={files} isConversionRunning />);
+
+    expect(screen.getByRole('button', { name: 'Remove all files' })).toBeDisabled();
+  });
+
+  it('should display a disabled remove all files button if conversion is not running but a file is still being converted', () => {
+    const files = [{ ...file1, status: fileStatusSchema.enum.converting }, file2, file3];
+    render(<FileList files={files} isConversionRunning={false} />);
+
+    expect(screen.getByRole('button', { name: 'Remove all files' })).toBeDisabled();
   });
 });

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -28,12 +28,13 @@ TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 type TooltipProps = {
   children?: React.ReactNode;
   content?: React.ReactNode;
+  delayDuration?: number;
   position?: 'top' | 'right' | 'bottom' | 'left';
 };
 
-export const Tooltip = ({ children, content, position }: TooltipProps) => {
+export const Tooltip = ({ children, content, delayDuration, position }: TooltipProps) => {
   return (
-    <TooltipProvider>
+    <TooltipProvider delayDuration={delayDuration}>
       <TooltipRoot>
         <TooltipTrigger asChild>{children}</TooltipTrigger>
         <TooltipContent side={position}>{content}</TooltipContent>

--- a/src/hooks/useConversionEvents.ts
+++ b/src/hooks/useConversionEvents.ts
@@ -6,8 +6,10 @@ export const useConversionEvents = () => {
   const setFileStatus = useStore(state => state.setFileStatus);
   const setFileProgress = useStore(state => state.setFileProgress);
   const setFileMetadata = useStore(state => state.setFileMetadata);
+  const setIsConversionRunning = useStore(state => state.setIsConversionRunning);
 
   useEffect(() => {
+    window.conversion.onConversionEnd(() => setIsConversionRunning(false));
     window.conversion.onFileConversionStart((_event, { filePath }) => {
       setFileStatus(filePath, fileStatusSchema.enum.converting);
     });

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -79,7 +79,8 @@
       "destinationSameAsSource": "Destination same as source",
       "selectDestination": "Select destination",
       "startConversion": "Start conversion",
-      "stopConversion": "Stop conversion"
+      "stopConversion": "Stop conversion",
+      "stopConversionTooltip": "Conversion will stop at the end of the file being converted"
     },
     "settings": {
       "title": "Settings"

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -79,7 +79,8 @@
       "destinationSameAsSource": "Destination identique à la source",
       "selectDestination": "Sélectionner la destination",
       "startConversion": "Démarrer la conversion",
-      "stopConversion": "Arrêter la conversion"
+      "stopConversion": "Arrêter la conversion",
+      "stopConversionTooltip": "La conversion s'arrêtera à la fin du fichier en cours de conversion"
     },
     "settings": {
       "title": "Paramètres"

--- a/src/routes/Converter.tsx
+++ b/src/routes/Converter.tsx
@@ -1,21 +1,22 @@
-import { fileStatusSchema } from 'schema';
 import { ConversionSettingsForm } from 'src/components/ConversionSettingsForm';
 import { FileImport } from 'src/components/FileImport';
 import { FileList } from 'src/components/FileList';
 import { Footer } from 'src/components/Footer';
-import { getDestinationPath, getFiles, getFilesToConvert, useStore } from 'src/store';
+import { getDestinationPath, getFiles, getFilesToConvert, getIsConversionRunning, useStore } from 'src/store';
 import type { ConversionSettings } from 'schema';
 
 export const Converter = () => {
   const files = useStore(getFiles);
   const filesToConvert = useStore(getFilesToConvert);
   const destinationPath = useStore(getDestinationPath);
+  const isConversionRunning = useStore(getIsConversionRunning);
+  const setIsConversionRunning = useStore(state => state.setIsConversionRunning);
 
   const isFileListDisplayed = files.length > 0;
   const isStartButtonDisabled = filesToConvert.length === 0;
-  const isConversionRunning = files.some(file => file.status === fileStatusSchema.enum.converting);
 
   const handleStartConversion = (conversionSettings: ConversionSettings) => {
+    setIsConversionRunning(true);
     window.conversion.startConversion({ conversionSettings, destinationPath, files: filesToConvert });
   };
 
@@ -25,12 +26,12 @@ export const Converter = () => {
     <div className="flex h-full flex-col">
       <div className="flex grow overflow-hidden">
         <section className="grow">
-          <FileImport isFileListDisplayed={isFileListDisplayed}>
-            <FileList files={files} />
+          <FileImport isDisabled={isConversionRunning} isFileListDisplayed={isFileListDisplayed}>
+            <FileList files={files} isConversionRunning={isConversionRunning} />
           </FileImport>
         </section>
         <section className="w-80 shrink-0 overflow-y-auto border-l p-4">
-          <ConversionSettingsForm onStartConversion={handleStartConversion} />
+          <ConversionSettingsForm isDisabled={isConversionRunning} onStartConversion={handleStartConversion} />
         </section>
       </div>
       <Footer

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -5,3 +5,4 @@ export const getFiles = (state: State) => Object.values(state.files);
 export const getFilesToConvert = (state: State) =>
   Object.values(state.files).filter(file => file.status === fileStatusSchema.enum.imported);
 export const getDestinationPath = (state: State) => state.destinationPath;
+export const getIsConversionRunning = (state: State) => state.isConversionRunning;

--- a/src/store/store.types.ts
+++ b/src/store/store.types.ts
@@ -4,6 +4,7 @@ import type { FileStatus, StreamsTitle, StreamsToCopy, VideoFile } from 'schema'
 export type State = {
   destinationPath: string;
   files: Record<string, VideoFile>;
+  isConversionRunning: boolean;
 };
 
 export type Actions = {
@@ -14,6 +15,7 @@ export type Actions = {
   setFileMetadata: (filePath: string, metadata: FfprobeData) => void;
   setFileProgress: (filePath: string, progress: number) => void;
   setFileStatus: (filePath: string, status: FileStatus) => void;
+  setIsConversionRunning: (isConversionRunning: boolean) => void;
   setStreamsTitle: (filePath: string, streamsTitle: StreamsTitle) => void;
   setStreamsToCopy: (filePath: string, streamsToCopy: StreamsToCopy) => void;
 };

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -7,6 +7,7 @@ export const useStore = create<Store>()(
   immer(set => ({
     destinationPath: '',
     files: {},
+    isConversionRunning: false,
     addFiles: files => {
       set(state => {
         files.forEach(file => {
@@ -53,6 +54,11 @@ export const useStore = create<Store>()(
     setDestinationPath: destinationPath => {
       set(state => {
         state.destinationPath = destinationPath;
+      });
+    },
+    setIsConversionRunning: isConversionRunning => {
+      set(state => {
+        state.isConversionRunning = isConversionRunning;
       });
     },
   })),


### PR DESCRIPTION
## Description
- send `conversion-end` event when all files have been converted
- add a tooltip on "Stop conversion" button
- new `isConversionRunning` state in store to know if the conversion is running
- conversion settings form is now disabled when the conversion is running
- file stream can only be editted when file is `imported`
- a file cannot be removed when the conversion or if the file is still being converted
- files cannot be added to file list when the conversion is running
- file list cannot be cleared when the conversion is running or if a file is still being converted
- destination input is disabled when the conversion is running
