### PR TITLE
feat(v2): display ffmpeg command

### DIFF
--- a/electron/ConversionManager.ts
+++ b/electron/ConversionManager.ts
@@ -36,7 +36,7 @@ export class ConversionManager {
               {
                 onFileConversionEnd: filePath => this.handleFileConversionEnd(filePath),
                 onFileConversionProgress: (filePath, progress) => this.handleFileConversionProgress(filePath, progress),
-                onFileConversionStart: filePath => this.handleFileConversionStart(filePath),
+                onFileConversionStart: (filePath, commandLine) => this.handleFileConversionStart(filePath, commandLine),
                 onFileConversionError: (filePath, error) => this.handleFileConversionError(filePath, error),
               },
             );
@@ -64,8 +64,8 @@ export class ConversionManager {
     });
   }
 
-  handleFileConversionStart(filePath: string) {
-    this.mainWindow.webContents.send('file-conversion-start', { filePath });
+  handleFileConversionStart(filePath: string, ffmpegCommand: string) {
+    this.mainWindow.webContents.send('file-conversion-start', { filePath, ffmpegCommand });
   }
 
   handleFileConversionProgress(filePath: string, progress: number) {

--- a/electron/conversion-events.types.ts
+++ b/electron/conversion-events.types.ts
@@ -3,7 +3,10 @@ import type { FfprobeData } from 'fluent-ffmpeg';
 
 export type ConversionEndCallback = (event: IpcRendererEvent) => void;
 
-export type FileConversionStartCallback = (event: IpcRendererEvent, { filePath }: { filePath: string }) => void;
+export type FileConversionStartCallback = (
+  event: IpcRendererEvent,
+  { ffmpegCommand, filePath }: { ffmpegCommand: string; filePath: string },
+) => void;
 
 export type FileConversionProgressCallback = (
   event: IpcRendererEvent,

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-select": "2.0.0",
     "@radix-ui/react-separator": "1.0.3",
     "@radix-ui/react-slot": "1.0.2",
+    "@radix-ui/react-switch": "1.0.3",
     "@radix-ui/react-tooltip": "1.0.7",
     "class-variance-authority": "0.7.0",
     "clsx": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ dependencies:
   '@radix-ui/react-slot':
     specifier: 1.0.2
     version: 1.0.2(@types/react@18.2.31)(react@18.2.0)
+  '@radix-ui/react-switch':
+    specifier: 1.0.3
+    version: 1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-tooltip':
     specifier: 1.0.7
     version: 1.0.7(@types/react-dom@18.2.14)(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0)
@@ -1525,6 +1528,33 @@ packages:
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.31)(react@18.2.0)
       '@types/react': 18.2.31
       react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-switch@1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-mxm87F88HyHztsI7N+ZUmEoARGkC22YVW5CaC+Byc+HRpuvCrOBPTAnXgf+tZ/7i0Sg/eOePGdMhUKhPaQEqow==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.31)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.31)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.31)(react@18.2.0)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.2.31)(react@18.2.0)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.31)(react@18.2.0)
+      '@types/react': 18.2.31
+      '@types/react-dom': 18.2.14
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@radix-ui/react-tooltip@1.0.7(@types/react-dom@18.2.14)(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0):

--- a/schema/file.types.ts
+++ b/schema/file.types.ts
@@ -9,6 +9,7 @@ export type StreamsTitle = Record<number, string>;
 
 export type VideoFile = {
   error?: string;
+  ffmpegCommand?: string;
   metadata?: FfprobeData;
   name: string;
   path: string;

--- a/src/components/FileCard/FileCard.tsx
+++ b/src/components/FileCard/FileCard.tsx
@@ -1,12 +1,13 @@
+import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { ChevronDownIcon, ChevronUpIcon, TrashIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { fileStatusSchema } from 'schema';
 import { useStore } from 'src/store';
-import { formatFileSize } from 'src/utils';
+import { formatFileSize, getSettingsFromStorage } from 'src/utils';
 import { StreamTable } from '../StreamTable';
 import { Button } from '../ui/Button';
-import { Card, CardDescription, CardHeader } from '../ui/Card';
+import { Card, CardContent, CardDescription, CardHeader } from '../ui/Card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/Collapsible';
 import { Progress } from '../ui/Progress';
 import { Tooltip } from '../ui/Tooltip';
@@ -20,15 +21,19 @@ type FileCardProps = {
 
 export const FileCard = ({ file, isConversionRunning }: FileCardProps) => {
   const { t } = useTranslation();
+  const [cardRef] = useAutoAnimate();
+  const settings = getSettingsFromStorage();
+
   const [isStreamTableOpen, setIsStreamTableOpen] = useState(false);
   const toggleStreamTableLabel = isStreamTableOpen ? t('fileList.file.hideStreams') : t('fileList.file.displayStreams');
 
-  const { error, metadata, name, path, progress, size, status, streamsTitle, streamsToCopy } = file;
+  const { error, ffmpegCommand, metadata, name, path, progress, size, status, streamsTitle, streamsToCopy } = file;
   const formattedFileSize = formatFileSize(size);
 
   const isProgressDisplayed = status === fileStatusSchema.enum.converting && progress > 0;
   const isRemoveButtonDisabled = isConversionRunning || status === fileStatusSchema.enum.converting;
   const isStreamEditDisabled = isConversionRunning || status !== fileStatusSchema.enum.imported;
+  const isFfmpegCommandDisplayed = settings.ffmpegCommand && Boolean(ffmpegCommand);
 
   const removeFile = useStore(state => state.removeFile);
   const setStreamsToCopy = useStore(state => state.setStreamsToCopy);
@@ -45,7 +50,7 @@ export const FileCard = ({ file, isConversionRunning }: FileCardProps) => {
   };
 
   return (
-    <Card className="relative">
+    <Card className="relative" ref={cardRef}>
       <div className="flex items-center px-6">
         <FileCardIcon error={error} status={status} />
         <CardHeader className="grow pb-0">
@@ -65,7 +70,12 @@ export const FileCard = ({ file, isConversionRunning }: FileCardProps) => {
           </Button>
         </Tooltip>
       </div>
-      <Collapsible className="mb-1" onOpenChange={setIsStreamTableOpen} open={isStreamTableOpen}>
+      {isFfmpegCommandDisplayed && (
+        <CardContent className="mt-2 pb-0">
+          <div className="code">{ffmpegCommand}</div>
+        </CardContent>
+      )}
+      <Collapsible className="my-1" onOpenChange={setIsStreamTableOpen} open={isStreamTableOpen}>
         <div className="flex justify-center">
           <Tooltip content={toggleStreamTableLabel}>
             <CollapsibleTrigger asChild className="flex justify-center">

--- a/src/components/FileCard/__tests__/FileCard.test.tsx
+++ b/src/components/FileCard/__tests__/FileCard.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import { fileStatusSchema } from 'schema';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { FileCard } from '../FileCard';
 import type { VideoFile } from 'schema';
+
+vi.mock('@formkit/auto-animate/react', () => ({
+  useAutoAnimate: vi.fn().mockReturnValue([]),
+}));
 
 const defaultFile = {
   name: 'matrix.mkv',

--- a/src/components/SettingsForm/FfmpegCommandSwitch.tsx
+++ b/src/components/SettingsForm/FfmpegCommandSwitch.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from 'react-i18next';
+import { FormControl, FormItem, FormLabel } from '../ui/Form';
+import { Switch } from '../ui/Switch';
+
+type FfmpegCommandSwitchProps = {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+};
+
+export const FfmpegCommandSwitch = ({ checked, onChange }: FfmpegCommandSwitchProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <FormItem className="flex flex-row items-center gap-2">
+      <FormLabel className="w-72 shrink-0">{t('settings.ffmpegCommand.label')}</FormLabel>
+      <FormControl>
+        <Switch checked={checked} onCheckedChange={onChange} />
+      </FormControl>
+    </FormItem>
+  );
+};

--- a/src/components/SettingsForm/LanguageSelect.tsx
+++ b/src/components/SettingsForm/LanguageSelect.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import i18n from 'src/i18n';
 import { languageSettingSchema } from 'src/schema/settings.schema';
 import { getLanguageFromLanguageSetting } from 'src/utils';
-import { FormControl, FormLabel } from '../ui/Form';
+import { FormControl, FormItem, FormLabel } from '../ui/Form';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/Select';
 import type { LanguageSetting } from 'src/schema/settings.schema';
 
@@ -22,8 +22,8 @@ export const LanguageSelect = ({ onChange, value }: LanguageSelectProps) => {
   };
 
   return (
-    <div className="flex items-center gap-2">
-      <FormLabel className="w-60">{t('settings.language.label')}</FormLabel>
+    <FormItem className="flex flex-row items-center gap-2">
+      <FormLabel className="w-72 shrink-0">{t('settings.language.label')}</FormLabel>
       <Select onValueChange={handleChange} value={value}>
         <FormControl>
           <SelectTrigger>
@@ -38,6 +38,6 @@ export const LanguageSelect = ({ onChange, value }: LanguageSelectProps) => {
           ))}
         </SelectContent>
       </Select>
-    </div>
+    </FormItem>
   );
 };

--- a/src/components/SettingsForm/NotificationsSelect.tsx
+++ b/src/components/SettingsForm/NotificationsSelect.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { notificationsSettingSchema } from 'src/schema/settings.schema';
-import { FormControl, FormLabel } from '../ui/Form';
+import { FormControl, FormItem, FormLabel } from '../ui/Form';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/Select';
 import type { NotificationsSetting } from 'src/schema/settings.schema';
 
@@ -27,8 +27,8 @@ export const NotificationsSelect = ({ onChange, value }: NotificationsSelectProp
   };
 
   return (
-    <div className="flex items-center gap-2">
-      <FormLabel className="w-60">{t('settings.notifications.label')}</FormLabel>
+    <FormItem className="flex flex-row items-center gap-2">
+      <FormLabel className="w-72 shrink-0">{t('settings.notifications.label')}</FormLabel>
       <Select onValueChange={handleChange} value={value}>
         <FormControl>
           <SelectTrigger>
@@ -43,6 +43,6 @@ export const NotificationsSelect = ({ onChange, value }: NotificationsSelectProp
           ))}
         </SelectContent>
       </Select>
-    </div>
+    </FormItem>
   );
 };

--- a/src/components/SettingsForm/SettingsForm.tsx
+++ b/src/components/SettingsForm/SettingsForm.tsx
@@ -1,16 +1,15 @@
 import { useSettingsForm } from 'src/hooks/useSettingsForm';
 import { getSettingsFromStorage, saveSettingsToStorage } from 'src/utils';
 import { Form, FormField } from '../ui/Form';
+import { FfmpegCommandSwitch } from './FfmpegCommandSwitch';
 import { LanguageSelect } from './LanguageSelect';
 import { NotificationsSelect } from './NotificationsSelect';
 import { ThemeSelect } from './ThemeSelect';
 import type { Settings } from 'src/schema/settings.schema';
 
 export const SettingsForm = () => {
-  const { language, notifications, theme } = getSettingsFromStorage();
-  const form = useSettingsForm({
-    defaultValues: { language, notifications, theme },
-  });
+  const settings = getSettingsFromStorage();
+  const form = useSettingsForm({ defaultValues: settings });
   const { control, handleSubmit } = form;
 
   const onSubmit = (data: Settings) => {
@@ -34,6 +33,11 @@ export const SettingsForm = () => {
           control={control}
           name="theme"
           render={({ field }) => <ThemeSelect onChange={field.onChange} value={field.value} />}
+        />
+        <FormField
+          control={control}
+          name="ffmpegCommand"
+          render={({ field }) => <FfmpegCommandSwitch checked={field.value} onChange={field.onChange} />}
         />
       </form>
     </Form>

--- a/src/components/SettingsForm/ThemeSelect.tsx
+++ b/src/components/SettingsForm/ThemeSelect.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { themeSettingSchema } from 'src/schema/settings.schema';
 import { useStore } from 'src/store';
-import { FormControl, FormLabel } from '../ui/Form';
+import { FormControl, FormItem, FormLabel } from '../ui/Form';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/Select';
 import type { ThemeSetting } from 'src/schema/settings.schema';
 
@@ -21,8 +21,8 @@ export const ThemeSelect = ({ onChange, value }: ThemeSelectProps) => {
   };
 
   return (
-    <div className="flex items-center gap-2">
-      <FormLabel className="w-60">{t('settings.theme.label')}</FormLabel>
+    <FormItem className="flex flex-row items-center gap-2">
+      <FormLabel className="w-72 shrink-0">{t('settings.theme.label')}</FormLabel>
       <Select onValueChange={handleChange} value={value}>
         <FormControl>
           <SelectTrigger>
@@ -37,6 +37,6 @@ export const ThemeSelect = ({ onChange, value }: ThemeSelectProps) => {
           ))}
         </SelectContent>
       </Select>
-    </div>
+    </FormItem>
   );
 };

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -16,7 +16,7 @@ const Checkbox = React.forwardRef<
     ref={ref}
     {...props}
   >
-    <CheckboxPrimitive.Indicator className={cn('text-current flex items-center justify-center')}>
+    <CheckboxPrimitive.Indicator className={cn('flex items-center justify-center text-current')}>
       <Check className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type,
   return (
     <input
       className={cn(
-        'file:bg-transparent flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       ref={ref}

--- a/src/components/ui/Switch.tsx
+++ b/src/components/ui/Switch.tsx
@@ -9,7 +9,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'border-transparent peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
       className,
     )}
     {...props}

--- a/src/components/ui/Switch.tsx
+++ b/src/components/ui/Switch.tsx
@@ -1,0 +1,27 @@
+import * as SwitchPrimitives from '@radix-ui/react-switch';
+import * as React from 'react';
+import { cn } from 'src/lib/utils';
+import type { PropsWithClassName } from './ui.types';
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & PropsWithClassName
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      'border-transparent peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        'pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0',
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/src/hooks/useConversionEvents.ts
+++ b/src/hooks/useConversionEvents.ts
@@ -11,6 +11,7 @@ export const useConversionEvents = () => {
   const setFileMetadata = useStore(state => state.setFileMetadata);
   const setIsConversionRunning = useStore(state => state.setIsConversionRunning);
   const setFileError = useStore(state => state.setFileError);
+  const setFileFfmpegCommand = useStore(state => state.setFileFfmpegCommand);
 
   useEffect(() => {
     window.conversion.onConversionEnd(() => {
@@ -20,8 +21,9 @@ export const useConversionEvents = () => {
         title: t('notifications.onConversionEnd.title'),
       });
     });
-    window.conversion.onFileConversionStart((_event, { filePath }) => {
+    window.conversion.onFileConversionStart((_event, { ffmpegCommand, filePath }) => {
       setFileStatus(filePath, fileStatusSchema.enum.converting);
+      setFileFfmpegCommand(filePath, ffmpegCommand);
     });
     window.conversion.onFileConversionProgress((_event, { filePath, progress }) => setFileProgress(filePath, progress));
     window.conversion.onFileConversionEnd((_event, { filePath }) => {

--- a/src/hooks/useConversionEvents.ts
+++ b/src/hooks/useConversionEvents.ts
@@ -39,5 +39,5 @@ export const useConversionEvents = () => {
     window.conversion.onFileMetadata((_event, { filePath, metadata }) => {
       setFileMetadata(filePath, metadata);
     });
-  }, [setIsConversionRunning, setFileError, setFileMetadata, setFileProgress, setFileStatus, t]);
+  }, [setFileFfmpegCommand, setIsConversionRunning, setFileError, setFileMetadata, setFileProgress, setFileStatus, t]);
 };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -101,6 +101,9 @@
       }
     },
     "settings": {
+      "ffmpegCommand": {
+        "label": "Display spawned FFmpeg command"
+      },
       "language": {
         "label": "Language",
         "values": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -101,6 +101,9 @@
       }
     },
     "settings": {
+      "ffmpegCommand": {
+        "label": "Afficher la commande FFmpeg générée"
+      },
       "language": {
         "label": "Langue",
         "values": {

--- a/src/schema/settings.schema.ts
+++ b/src/schema/settings.schema.ts
@@ -13,5 +13,6 @@ export const settingsSchema = z.object({
   language: languageSettingSchema,
   notifications: notificationsSettingSchema,
   theme: themeSettingSchema,
+  ffmpegCommand: z.boolean(),
 });
 export type Settings = z.infer<typeof settingsSchema>;

--- a/src/store/store.types.ts
+++ b/src/store/store.types.ts
@@ -17,6 +17,7 @@ export type Actions = {
   setConversionSettings: (conversionSettings: ConversionSettings) => void;
   setDestinationPath: (destinationPath: string) => void;
   setFileError: (filePath: string, error: string) => void;
+  setFileFfmpegCommand: (filePath: string, ffmpegCommand: string) => void;
   setFileMetadata: (filePath: string, metadata: FfprobeData) => void;
   setFileProgress: (filePath: string, progress: number) => void;
   setFileStatus: (filePath: string, status: FileStatus) => void;

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -57,6 +57,11 @@ export const useStore = create<Store>()(
         state.files[filePath].error = error;
       });
     },
+    setFileFfmpegCommand: (filePath, ffmpegCommand) => {
+      set(state => {
+        state.files[filePath].ffmpegCommand = ffmpegCommand;
+      });
+    },
     setStreamsTitle: (filePath, streamsTitle) => {
       set(state => {
         state.files[filePath].streamsTitle = streamsTitle;

--- a/src/utils/__tests__/settings.utils.test.ts
+++ b/src/utils/__tests__/settings.utils.test.ts
@@ -13,6 +13,7 @@ describe('settings.utils', () => {
         language: languageSettingSchema.enum.auto,
         notifications: notificationsSettingSchema.enum.disabled,
         theme: themeSettingSchema.enum.system,
+        ffmpegCommand: false,
       });
     });
 
@@ -21,6 +22,7 @@ describe('settings.utils', () => {
         language: languageSettingSchema.enum.fr,
         notifications: notificationsSettingSchema.enum.onConversionEnd,
         theme: themeSettingSchema.enum.dark,
+        ffmpegCommand: true,
       };
       localStorage.setItem('recode-converter.settings', JSON.stringify(settings));
 
@@ -28,6 +30,19 @@ describe('settings.utils', () => {
         language: languageSettingSchema.enum.fr,
         notifications: notificationsSettingSchema.enum.onConversionEnd,
         theme: themeSettingSchema.enum.dark,
+        ffmpegCommand: true,
+      });
+    });
+
+    it('should return all settings even if all settings are not defined in local storage', () => {
+      const settings = { language: languageSettingSchema.enum.fr };
+      localStorage.setItem('recode-converter.settings', JSON.stringify(settings));
+
+      expect(getSettingsFromStorage()).toEqual({
+        language: languageSettingSchema.enum.fr,
+        notifications: notificationsSettingSchema.enum.disabled,
+        theme: themeSettingSchema.enum.system,
+        ffmpegCommand: false,
       });
     });
   });

--- a/src/utils/settings.utils.ts
+++ b/src/utils/settings.utils.ts
@@ -7,12 +7,13 @@ const defaultSettings: Settings = {
   language: languageSettingSchema.enum.auto,
   notifications: notificationsSettingSchema.enum.disabled,
   theme: themeSettingSchema.enum.system,
+  ffmpegCommand: false,
 };
 
 export function getSettingsFromStorage() {
   const settings = localStorage.getItem(STORAGE_KEY);
 
-  return settings ? (JSON.parse(settings) as Settings) : defaultSettings;
+  return settings ? { ...defaultSettings, ...(JSON.parse(settings) as Settings) } : defaultSettings;
 }
 
 export function saveSettingsToStorage(settings: Settings) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,47 +10,47 @@ module.exports = {
         '2xl': '1400px',
       },
     },
-    colors: {
-      border: 'hsl(var(--border))',
-      input: 'hsl(var(--input))',
-      ring: 'hsl(var(--ring))',
-      background: 'hsl(var(--background))',
-      foreground: 'hsl(var(--foreground))',
-      primary: {
-        DEFAULT: 'hsl(var(--primary))',
-        foreground: 'hsl(var(--primary-foreground))',
-      },
-      secondary: {
-        DEFAULT: 'hsl(var(--secondary))',
-        foreground: 'hsl(var(--secondary-foreground))',
-      },
-      destructive: {
-        DEFAULT: 'hsl(var(--destructive))',
-        foreground: 'hsl(var(--destructive-foreground))',
-      },
-      muted: {
-        DEFAULT: 'hsl(var(--muted))',
-        foreground: 'hsl(var(--muted-foreground))',
-      },
-      accent: {
-        DEFAULT: 'hsl(var(--accent))',
-        foreground: 'hsl(var(--accent-foreground))',
-      },
-      popover: {
-        DEFAULT: 'hsl(var(--popover))',
-        foreground: 'hsl(var(--popover-foreground))',
-      },
-      card: {
-        DEFAULT: 'hsl(var(--card))',
-        foreground: 'hsl(var(--card-foreground))',
-      },
-      success: 'hsl(var(--success))',
-    },
     extend: {
       borderRadius: {
         lg: 'var(--radius)',
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',
+      },
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+        success: 'hsl(var(--success))',
       },
       keyframes: {
         'accordion-down': {


### PR DESCRIPTION
## Description
- display spawned ffmpeg command after conversion start if related setting is set to true
- send ffmpeg command from main to renderer in `fileConversionStart` callback and set it in according file object in store
- add `ffmpegCommand` boolean setting (default to false) in settings form, it's displayed as a switch
- add UI component: Switch
- fix settings label by using `FormItem` to wrap form selects + increase label width in settings form
- `getSettingsFromStorage` now returns settings in local storage with default settings to avoid missing setting if a single setting is not defined in local storage
