### PR TITLE
ci(v2): release flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,29 +1,35 @@
-name: Build/release
+name: Build release
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 jobs:
-  release:
+  build:
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v1
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v2
         with:
-          node-version: 13
+          version: 8
 
-      - name: Build & release Electron app
-        uses: samuelmeuli/action-electron-builder@v1
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
         with:
-          github_token: ${{ secrets.github_token }}
-          release: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          node-version: 18
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: node
+          token: ${{ secrets.RELEASE_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog
+
+## [1.2.0](https://github.com/murgatt/recode-converter/compare/v1.1.0...v1.2.0) (2020-11-28)
+
+### Features
+
+- add front side console error when conversion fails ([#65](https://github.com/murgatt/recode-converter/issues/65)) ([ce1647e](https://github.com/murgatt/recode-converter/commit/ce1647e87a415b89296f0b674c6b155d498d9179))
+- **player:** add fullscreen mode ([#62](https://github.com/murgatt/recode-converter/issues/62)) ([d479e65](https://github.com/murgatt/recode-converter/commit/d479e65e1c1ab7438f83106468dac09b8076cc44))
+- [beta] video comparison slider ([#59](https://github.com/murgatt/recode-converter/issues/59)) ([f8dc476](https://github.com/murgatt/recode-converter/commit/f8dc476ded21996e974fd127354babafdcc4dced))
+- add an app menu ([#58](https://github.com/murgatt/recode-converter/issues/58)) ([214fe21](https://github.com/murgatt/recode-converter/commit/214fe21a3308b2d60d59818d5186ecba31622f11))
+
+### Bug Fixes
+
+- conversion error when destination is 'Same as source' ([#64](https://github.com/murgatt/recode-converter/issues/64)) ([ec1dd6b](https://github.com/murgatt/recode-converter/commit/ec1dd6bdab0514423cf570927e80f3785623c5fa))
+
+## [1.1.0](https://github.com/murgatt/recode-converter/compare/v1.0.0...v1.1.0) (2020-08-08)
+
+### Features
+
+- check for available update on start ([#53](https://github.com/murgatt/recode-converter/issues/53)) ([d23b3e4](https://github.com/murgatt/recode-converter/commit/d23b3e40fa3c2acc8a2b6f5a23ebcf8c197be0f6))
+
+## [1.0.0](https://github.com/murgatt/recode-converter/compare/v0.5.0...v1.0.0) (2020-08-08)
+
+### Bug Fixes
+
+- **conversion:** wrong status if file added during conversion ([#52](https://github.com/murgatt/recode-converter/issues/52)) ([1c7e204](https://github.com/murgatt/recode-converter/commit/1c7e204002a89642c103e98b40348850f05f08f1))
+
+## [0.5.0](https://github.com/murgatt/recode-converter/compare/v0.4.0...v0.5.0) (2020-08-07)
+
+### Features
+
+- check if FFMPEG is installed ([#50](https://github.com/murgatt/recode-converter/issues/50)) ([1172f90](https://github.com/murgatt/recode-converter/commit/1172f90fa9185756dd3bb05150a111291c0bd788))
+- remove useless start screen ([#51](https://github.com/murgatt/recode-converter/issues/51)) ([5f35f14](https://github.com/murgatt/recode-converter/commit/5f35f14d833646748d13c2bb083952c853636eb9))
+
+## [0.4.0](https://github.com/murgatt/recode-converter/compare/v0.3.0...v0.4.0) (2020-07-31)
+
+### Bug Fixes
+
+- app crash on mac when using ffmpeg or ffprobe ([#49](https://github.com/murgatt/recode-converter/issues/49)) ([cde15f6](https://github.com/murgatt/recode-converter/commit/cde15f64dd5a495785e82543e767d6a6069caba5))
+
+## [0.3.0](https://github.com/murgatt/recode-converter/compare/v0.2.0...v0.3.0) (2020-06-06)
+
+### Features
+
+- improve file streams edit UI ([#40](https://github.com/murgatt/recode-converter/issues/40)) ([f275c86](https://github.com/murgatt/recode-converter/commit/f275c8673da3c4ea852146ab2de89d7ea97b1ec4))
+- **conversion:** add & edit stream title ([#38](https://github.com/murgatt/recode-converter/issues/38)) ([9392a6b](https://github.com/murgatt/recode-converter/commit/9392a6b8c75fc5217b91e4516a91956d3d0889e4))
+- **conversion:** allow to remove specific streams from the output file ([#36](https://github.com/murgatt/recode-converter/issues/36)) ([bf532de](https://github.com/murgatt/recode-converter/commit/bf532deb4f25c40bf9bb66bb1423d11e343810ab))
+- **files:** add file streams info in a collapse panel ([#35](https://github.com/murgatt/recode-converter/issues/35)) ([aa2d30f](https://github.com/murgatt/recode-converter/commit/aa2d30f34f547cfe188dc04f6354e7595b821b88))
+- add node-ffprobe to get files info ([#34](https://github.com/murgatt/recode-converter/issues/34)) ([15d812d](https://github.com/murgatt/recode-converter/commit/15d812d009b18728e514228199cd18dd54924d41))
+
+### Bug Fixes
+
+- **conversion:** conversion error when metadata with spaces ([#41](https://github.com/murgatt/recode-converter/issues/41)) ([2fe8b18](https://github.com/murgatt/recode-converter/commit/2fe8b187ae4238f3e19b37324e1b63ab74dbf6cb))
+- **conversion:** metadata on ignored stream ([#42](https://github.com/murgatt/recode-converter/issues/42)) ([4162636](https://github.com/murgatt/recode-converter/commit/41626361128e001ba5211d9f72767641179d370d))
+
+## [0.2.0](https://github.com/murgatt/recode-converter/compare/v0.1.2...v0.2.0) (2020-05-18)
+
+### Features
+
+- add custom dark & light themes ([#27](https://github.com/murgatt/recode-converter/issues/27)) ([631f030](https://github.com/murgatt/recode-converter/commit/631f03017a201bb1e4bfa5a56a6ac823f5e96b1a))
+- add file drop zone on file list ([#26](https://github.com/murgatt/recode-converter/issues/26)) ([a831cae](https://github.com/murgatt/recode-converter/commit/a831caed6b27eab2eafc806ac10d7d85a180a1c9))
+- add file drop zone on home page ([#25](https://github.com/murgatt/recode-converter/issues/25)) ([52cd62f](https://github.com/murgatt/recode-converter/commit/52cd62f17923c111329f99a7cff9715e48f693f6))
+- add french language & set system language as default ([#30](https://github.com/murgatt/recode-converter/issues/30)) ([79ae6cb](https://github.com/murgatt/recode-converter/commit/79ae6cb7ffc0c1cc6a15c28f71635e89768c45f5))
+- add sample rate & channels audio settings ([#28](https://github.com/murgatt/recode-converter/issues/28)) ([f421b08](https://github.com/murgatt/recode-converter/commit/f421b08021f8bc0fd3b19639167e62ec055f1bcf))
+- display file size instead of file path ([e378a88](https://github.com/murgatt/recode-converter/commit/e378a884ef08380cf9eee9d6e0fb01efddcb654c))
+
+### Bug Fixes
+
+- Windows installer error ([#31](https://github.com/murgatt/recode-converter/issues/31)) ([923c077](https://github.com/murgatt/recode-converter/commit/923c077f523295dc48c4cd7db53e9320b0b8f127))
+- **mac:** fatal conversion error after main window is closed ([#32](https://github.com/murgatt/recode-converter/issues/32)) ([fdb7083](https://github.com/murgatt/recode-converter/commit/fdb70837192ad07e7099ac55120b21811564ef49))
+- **windows:** default destination is not displayed in Windows ([#33](https://github.com/murgatt/recode-converter/issues/33)) ([68de1bc](https://github.com/murgatt/recode-converter/commit/68de1bc3779849130cad46b28f41f1d9cda86c8f))
+- end conversion when an error occurred ([09ee21c](https://github.com/murgatt/recode-converter/commit/09ee21c90f532084ac2b7d1a58b346182833494a))
+- reset conversion settings on codec change ([#29](https://github.com/murgatt/recode-converter/issues/29)) ([95e0ded](https://github.com/murgatt/recode-converter/commit/95e0dedf1e77a79a7345bc5e74c0ceb39fa37910))
+
+### [0.1.2](https://github.com/murgatt/recode-converter/compare/v0.1.1...v0.1.2) (2020-04-06)
+
+### [0.1.1](https://github.com/murgatt/recode-converter/compare/v0.1.0...v0.1.1) (2020-04-06)
+
+### Features
+
+- add snackbar alert system ([#24](https://github.com/murgatt/recode-converter/issues/24)) ([a318bd7](https://github.com/murgatt/recode-converter/commit/a318bd75614fd323d2625a516727de17c17724f3))
+- conversion pause ([#23](https://github.com/murgatt/recode-converter/issues/23)) ([54a7032](https://github.com/murgatt/recode-converter/commit/54a7032497c0b4af3e4a5fa67d02d46769d51e10))
+
+## 0.1.0 (2020-03-28)
+
+### Features
+
+- add i18next & react-i18next ([#3](https://github.com/murgatt/recode-converter/issues/3)) ([221debb](https://github.com/murgatt/recode-converter/commit/221debb55d7f75a8ab810b2c80b1d4d63548af63))
+- add Select component ([#7](https://github.com/murgatt/recode-converter/issues/7)) ([32f2e26](https://github.com/murgatt/recode-converter/commit/32f2e261a512e05c621dc0ccf1a71125d44f5c2e))
+- conversion settings ([#6](https://github.com/murgatt/recode-converter/issues/6)) ([5382ba1](https://github.com/murgatt/recode-converter/commit/5382ba10227ce98b215efeaa21de2920e5b68f4f))
+- convert all files in the list ([#4](https://github.com/murgatt/recode-converter/issues/4)) ([6faeb04](https://github.com/murgatt/recode-converter/commit/6faeb04181914a614cc8e71b771429d71997b00c))
+- enhance global UI & UX ([#8](https://github.com/murgatt/recode-converter/issues/8)) ([2702c46](https://github.com/murgatt/recode-converter/commit/2702c46243dd8cc0d09606324a6c27160a3f0246))
+- main converter with simple UI ([#2](https://github.com/murgatt/recode-converter/issues/2)) ([2e06ef2](https://github.com/murgatt/recode-converter/commit/2e06ef29026942964682ff6f8481b1b57cd6f090))
+- **core:** clean main App file & create routes ([f4eba53](https://github.com/murgatt/recode-converter/commit/f4eba538dc47b19c9adf69954bbc4c84ff1c3c91))
+- **core:** create redux store ([#1](https://github.com/murgatt/recode-converter/issues/1)) ([49d8941](https://github.com/murgatt/recode-converter/commit/49d89419e143a5dac7564b90b5e2e6640df06fa8))
+- **dependencies:** add fluent-ffmpeg and react-router ([9ae235d](https://github.com/murgatt/recode-converter/commit/9ae235d84444fe98031ee035da7b14a20e7ba251))
+- **ffmpeg:** create main ffmpeg file ([86ff6ed](https://github.com/murgatt/recode-converter/commit/86ff6ed19fb4f554461e006569044831aaf613c7))
+
+### Bug Fixes
+
+- electron build ([#5](https://github.com/murgatt/recode-converter/issues/5)) ([b65c15d](https://github.com/murgatt/recode-converter/commit/b65c15d4d69ff86221c56c4643ed997c003459e0))
+- file input onChange is not triggered ([#11](https://github.com/murgatt/recode-converter/issues/11)) ([2e1a1db](https://github.com/murgatt/recode-converter/commit/2e1a1db98b2cfa4e37ceb9379e79aa82ab07365b))

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -6,6 +6,10 @@
   "appId": "YourAppID",
   "asar": true,
   "productName": "YourAppName",
+  "publish": {
+    provider: "github",
+    releaseType: "release"
+  },
   "directories": {
     "output": "release/${version}"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recode-converter",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "description": "A modern & simple audio converter for video files",
   "private": false,
   "repository": {


### PR DESCRIPTION
## Description
- update build action:
  - run when a release is published
  - setup, install dependencies & run build manually with `pnpm run build` script
  - publish app automatically by uploading artifacts to latest release with [electron builder](https://www.electron.build/configuration/publish.html)
- add [release-please-action](https://github.com/google-github-actions/release-please-action) to create release PR, update changelog & create release automatically
- add back CHANGELOG.md (from main) and remove standard version description
- set version to `1.2.0` (will bump later automatically to `2.0.0` with release-please)