### PR TITLE
fix(v2): minor fixes

### DIFF
--- a/electron/convert/convert.ts
+++ b/electron/convert/convert.ts
@@ -1,6 +1,12 @@
 /// <reference types="fluent-ffmpeg" />
 import ffmpeg from 'fluent-ffmpeg';
-import { getIgnoredStreamsOptions, getOutputOptions, getOutputPath, getStreamsTitleOptions } from './convert.utils';
+import {
+  getIgnoredStreamsIndex,
+  getIgnoredStreamsOptions,
+  getOutputOptions,
+  getOutputPath,
+  getStreamsTitleOptions,
+} from './convert.utils';
 import type { ConversionSettings, VideoFile } from '../../schema';
 import type { ProgressInfo } from 'electron-builder';
 
@@ -28,15 +34,17 @@ export function convert(
   const inputPath = file.path;
   const outputPath = getOutputPath(inputPath, destinationPath);
   const outputOptions = getOutputOptions(conversionSettings);
-  const ignoredStreamsOptions = getIgnoredStreamsOptions(file.streamsToCopy);
-  const streamsTitleOptions = getStreamsTitleOptions(file.streamsTitle);
+  const ignoredStreamsIndex = getIgnoredStreamsIndex(file.streamsToCopy);
+  const ignoredStreamsOptions = getIgnoredStreamsOptions(ignoredStreamsIndex);
+  const streamsTitleOptions = getStreamsTitleOptions(file.streamsTitle, ignoredStreamsIndex);
 
   const command = ffmpeg()
     .input(inputPath)
     .output(outputPath)
     .outputOptions(outputOptions)
     .outputOptions(ignoredStreamsOptions)
-    .outputOptions(streamsTitleOptions);
+    // @ts-ignore - Workaround to avoid error when there is spaces in stream title
+    .outputOptions(...streamsTitleOptions);
 
   return new Promise<void>((resolve, reject) => {
     command

--- a/src/components/StreamTable/StreamTablePropertiesCell.tsx
+++ b/src/components/StreamTable/StreamTablePropertiesCell.tsx
@@ -8,12 +8,13 @@ type StreamTablePropertiesCellProps = {
 export const StreamTablePropertiesCell = ({ stream }: StreamTablePropertiesCellProps) => {
   const { t } = useTranslation();
   const { bit_rate, channels, channel_layout, codec_type, height, sample_rate, width } = stream;
+  const isBitrateDisplayed = Boolean(bit_rate) && bit_rate !== 'N/A'; // TODO: test
 
   if (codec_type === 'audio') {
     return (
       <div>
         <p>{t('streams.properties.channels', { count: channels, layout: channel_layout })}</p>
-        {bit_rate && <p>{Number(bit_rate) / 1000} kbps</p>}
+        {isBitrateDisplayed && <p>{Number(bit_rate) / 1000} kbps</p>}
         <p>{sample_rate} Hz</p>
       </div>
     );


### PR DESCRIPTION
## Description
- fix title metadata with spaces causing error in output command generated by fluent-ffmpeg
- fix bitrate displayed as `NaN` in stream properties when there is no bitrate (value is `N/A`)
- fix wrong stream index when setting a stream title and at least one stream (before in the stream list) has been ignored