### PR TITLE
feat(v2): add about page

### DIFF
--- a/src/components/AppMenu/AppMenu.tsx
+++ b/src/components/AppMenu/AppMenu.tsx
@@ -1,4 +1,4 @@
-import { HomeIcon, SettingsIcon } from 'lucide-react';
+import { HelpCircleIcon, HomeIcon, SettingsIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { NavigationMenu, NavigationMenuList } from '../ui/NavigationMenu';
 import { AppMenuItem } from './AppMenuItem';
@@ -14,6 +14,9 @@ export const AppMenu = () => {
         </AppMenuItem>
       </NavigationMenuList>
       <NavigationMenuList className="flex-col">
+        <AppMenuItem label={t('appMenu.about')} to="/about">
+          <HelpCircleIcon size="16" />
+        </AppMenuItem>
         <AppMenuItem label={t('appMenu.settings')} to="/settings">
           <SettingsIcon size="16" />
         </AppMenuItem>

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+type ExternalLinkProps = {
+  href: string;
+} & React.AnchorHTMLAttributes<HTMLAnchorElement>;
+
+export const ExternalLink = React.forwardRef<HTMLAnchorElement, ExternalLinkProps>(
+  ({ children, href, ...otherProps }, ref) => {
+    const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      window.electron.openExternalLink(href);
+    };
+
+    return (
+      <a href={href} ref={ref} {...otherProps} onClick={handleClick}>
+        {children}
+      </a>
+    );
+  },
+);
+
+ExternalLink.displayName = 'ExternalLink';

--- a/src/components/UpdateAvailableModal.tsx
+++ b/src/components/UpdateAvailableModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { APP_WEBSITE_URL } from 'src/constants';
 import { version } from '../../package.json';
 import {
   AlertDialog,
@@ -13,7 +14,6 @@ import {
 } from './ui/AlertDialog';
 
 const GITHUB_API_URL = 'https://api.github.com/repos/murgatt/recode-converter/releases/latest';
-const APP_WEBSITE_URL = 'https://murgatt.github.io/recode-converter/';
 
 export const UpdateAvailableModal = () => {
   const { t } = useTranslation();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+export const APP_WEBSITE_URL = 'https://murgatt.github.io/recode-converter/';
+export const AUTHOR_GITHUB_URL = 'https://github.com/murgatt/';
+export const GITHUB_REPOSITORY_URL = 'https://github.com/murgatt/recode-converter';

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,6 +1,13 @@
 {
   "translation": {
+    "about": {
+      "appIconAlt": "Recode Converter icon",
+      "developedBy": "Developed by",
+      "githubLabel": "GitHub repository",
+      "websiteLabel": "Website"
+    },
     "appMenu": {
+      "about": "About",
       "home": "Converter",
       "settings": "Settings"
     },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1,6 +1,13 @@
 {
   "translation": {
+    "about": {
+      "appIconAlt": "Icône de Recode Converter",
+      "developedBy": "Développé par",
+      "githubLabel": "Dépôt GitHub",
+      "websiteLabel": "Site web-"
+    },
     "appMenu": {
+      "about": "A propos",
       "home": "Convertisseur",
       "settings": "Paramètres"
     },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -4,7 +4,7 @@
       "appIconAlt": "Icône de Recode Converter",
       "developedBy": "Développé par",
       "githubLabel": "Dépôt GitHub",
-      "websiteLabel": "Site web-"
+      "websiteLabel": "Site web"
     },
     "appMenu": {
       "about": "A propos",

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,6 @@
 import { createHashRouter } from 'react-router-dom';
 import { App } from './App';
+import { About } from './routes/About';
 import { Converter } from './routes/Converter';
 import { Settings } from './routes/Settings';
 
@@ -14,6 +15,10 @@ export const router = createHashRouter([
       {
         path: '/settings',
         element: <Settings />,
+      },
+      {
+        path: '/about',
+        element: <About />,
       },
     ],
   },

--- a/src/routes/About.tsx
+++ b/src/routes/About.tsx
@@ -1,0 +1,43 @@
+import { GithubIcon, LinkIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { ExternalLink } from 'src/components/ExternalLink';
+import { Button } from 'src/components/ui/Button';
+import { Tooltip } from 'src/components/ui/Tooltip';
+import { APP_WEBSITE_URL, AUTHOR_GITHUB_URL, GITHUB_REPOSITORY_URL } from 'src/constants';
+import { version } from '../../package.json';
+
+export const About = () => {
+  const { t } = useTranslation();
+
+  return (
+    <section className="flex h-screen flex-col items-center overflow-y-auto p-6">
+      <img alt={t('about.appIconAlt')} className="w-48 max-w-full" src="/icon.png" />
+      <div className="flex w-full flex-col items-center gap-3">
+        <h1 className="title-lg w-full text-center">Recode Converter</h1>
+        <p className="caption-sm">v{version}</p>
+        <p className="paragraph-sm">
+          {t('about.developedBy')}{' '}
+          <ExternalLink className="underline underline-offset-4" href={AUTHOR_GITHUB_URL}>
+            @murgatt
+          </ExternalLink>
+        </p>
+        <div className="flex gap-1">
+          <Tooltip content={t('about.githubLabel')} position="bottom">
+            <Button aria-label={t('about.githubLabel')} asChild size="icon" variant="ghost">
+              <ExternalLink href={GITHUB_REPOSITORY_URL}>
+                <GithubIcon size="16" />
+              </ExternalLink>
+            </Button>
+          </Tooltip>
+          <Tooltip content={t('about.websiteLabel')} position="bottom">
+            <Button aria-label={t('about.websiteLabel')} asChild size="icon" variant="ghost">
+              <ExternalLink href={APP_WEBSITE_URL}>
+                <LinkIcon size="16" />
+              </ExternalLink>
+            </Button>
+          </Tooltip>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/routes/About.tsx
+++ b/src/routes/About.tsx
@@ -11,7 +11,7 @@ export const About = () => {
 
   return (
     <section className="flex h-screen flex-col items-center overflow-y-auto p-6">
-      <img alt={t('about.appIconAlt')} className="w-48 max-w-full" src="/icon.png" />
+      <img alt={t('about.appIconAlt')} className="w-48 max-w-full" src="./icon.png" />
       <div className="flex w-full flex-col items-center gap-3">
         <h1 className="title-lg w-full text-center">Recode Converter</h1>
         <p className="caption-sm">v{version}</p>


### PR DESCRIPTION
## Description
- add about page with app version and link to github user, github repo & website
- add `ExternalLink` component to open link in default browser with electron API
- externalise some constants in a global `constants.ts` (`APP_WEBSITE_URL`, `AUTHOR_GITHUB_URL`, `GITHUB_REPOSITORY_URL`)
