### PR TITLE
fix(v2): fix default destination path on Windows

### DIFF
--- a/src/test/vitest-setup.ts
+++ b/src/test/vitest-setup.ts
@@ -1,2 +1,5 @@
 import '@testing-library/jest-dom/vitest';
 import 'src/i18n';
+
+// @ts-ignore userAgentData is experimental, TypeScript does not have the type declarations
+navigator.userAgentData = { platform: 'macOS' };

--- a/src/utils/file.utils.ts
+++ b/src/utils/file.utils.ts
@@ -16,7 +16,10 @@ export function formatFileSize(fileSize: number): string {
 }
 
 export function getDirectoryPathFromFile(file: VideoFile) {
-  return file.path.split('/').slice(0, -1).join('/');
+  // @ts-ignore userAgentData is experimental, TypeScript does not have the type declarations
+  const pathSeparator = navigator.userAgentData.platform === 'Windows' ? '\\' : '/';
+
+  return file.path.split(pathSeparator).slice(0, -1).join(pathSeparator);
 }
 
 export function areFilesFromSameDirectory(files: VideoFile[]) {


### PR DESCRIPTION
## Description
On Windows, when a file is added, we should see the directory has default destination path in destination input. Instead we only see "Destination" placeholder.
This is because on Windows path separator is `\\` instead of `/`.

When checking if all files are from same directory, we now check the platform and change path separator if Windows.

## How to test
- On Windows, open app and add one file (or multiple files from same directory)
- We should see the directory as destination path

