### PR TITLE
fix: Mac app cannot be opened

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -20,7 +20,12 @@
   ],
   "mac": {
     "target": [
-      "dmg"
+      {
+        "target": "dmg",
+        "arch": [
+          "universal"
+        ]
+      }
     ],
     "artifactName": "${productName}-Mac-${version}-Installer.${ext}"
   },


### PR DESCRIPTION
## Description

**Context**
Once downloaded and installed on a Mac, the app cannot be opened since `2.0.4`.
The target architecture was not specified and it automatically switched from `universal` to `arm64` changing how the Gatekeeper is warning about unsigned app and blocking it completely.

**Fix**
Set `universal` as target architecture for Mac build

## How to test
Build app, download and install it. It's now possible to open by right clicking on it.
