### PR TITLE
refactor: replace File.path with getPathForFile

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -9,6 +9,7 @@ import type {
 import type { ConversionSettings, VideoFile } from '../schema';
 
 export interface IElectron {
+  getFilePath: (file: File) => string;
   openDirectory: () => Promise<string>;
   openExternalLink: (url: string) => Promise<void>;
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,7 +1,8 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import type { IConversion, IElectron } from './electron-env';
 
 contextBridge.exposeInMainWorld('electron', {
+  getFilePath: file => webUtils.getPathForFile(file),
   openDirectory: () => ipcRenderer.invoke('dialog:openDirectory'),
   openExternalLink: url => ipcRenderer.invoke('shell:openExternalLink', url),
 } as IElectron);

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -22,8 +22,9 @@ export const useStore = create<Store>()(
     addFiles: files => {
       set(state => {
         files.forEach(file => {
-          state.files[file.path] = formatFileObject(file);
-          window.conversion.getMetadata({ filePath: file.path });
+          const filePath = window.electron.getFilePath(file);
+          state.files[filePath] = formatFileObject(file, filePath);
+          window.conversion.getMetadata({ filePath });
         });
       });
     },

--- a/src/utils/file.utils.ts
+++ b/src/utils/file.utils.ts
@@ -28,10 +28,10 @@ export function areFilesFromSameDirectory(files: VideoFile[]) {
   });
 }
 
-export function formatFileObject(file: File): VideoFile {
+export function formatFileObject(file: File, path: string): VideoFile {
   return {
     name: file.name,
-    path: file.path,
+    path,
     progress: 0,
     size: file.size,
     status: 'imported',


### PR DESCRIPTION
## Description

`File.path` is removed from version `32.0.0` of Electron, `webUtils.getPathForFile` should be used instead
- [v32.0.0 release note](https://github.com/electron/electron/releases/tag/v32.0.0)
- [Breaking change doc](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#removed-filepath)
