### PR TITLE
ci: remove old branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
-      - feat/v2
   pull_request:
     types:
       - opened


### PR DESCRIPTION
## Description

Remove `master` and `feat/v2` from main GitHub workflow