### PR TITLE
fix: app crash on Intel Macs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,6 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm run build
+        run: pnpm run build ${{ matrix.os == 'macos-latest' && '--universal' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, macos-13, ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout code

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -21,13 +21,11 @@
   "mac": {
     "target": [
       {
-        "target": "dmg",
-        "arch": [
-          "universal"
-        ]
+        "target": "dmg"
       }
     ],
-    "artifactName": "${productName}-Mac-${version}-Installer.${ext}"
+    "artifactName": "${productName}-Mac-${arch}-${version}-Installer.${ext}",
+    "category": "public.app-category.utilities"
   },
   "win": {
     "target": [


### PR DESCRIPTION
## Description

**Context**
The application is crashing on Intel based Macs.

**Why**
- Before #254 the app was built without specifying any architecture
- This cause the app to be built for the os used in the [GitHub action](https://github.com/murgatt/recode-converter/blob/main/.github/workflows/build.yml#L13), at the time it was an Intel mac so the built app was for Intel Macs but it could be opened on Silicon Mac with Rosetta (very low performance)
- When `macos-latest` switched to a Silicon Mac, the built app was for Silicon Mac only
- After #254 there was a specified architecture `universal` to try to build for all Macs, but as we integrate ffmpeg that need to be downloaded for a specific architecture, the build was broken for Intel Macs

**Fix**
As we can't create a unique build for all Macs (or an Intel one with low performance on Silicon), we now build the app on both architectures `macos-latest` and `maocs-13` in the GitHub action that create a `.dmg` installer for each.
