### PR TITLE
ci: migrate release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: node
           token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
## Description
release-please-action repo has moved from [google-github-actions](https://github.com/google-github-actions/release-please-action) to [googleapis](https://github.com/googleapis/release-please-action) and is now deprecated
