### PR TITLE
chore: add tailwindFunctions in prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,6 @@
   "singleQuote": true,
   "trailingComma": "all",
   "plugins": ["prettier-plugin-tailwindcss"],
-  "tailwindStylesheet": "./src/index.css"
+  "tailwindStylesheet": "./src/index.css",
+  "tailwindFunctions": ["clsx", "cn", "cx", "twMerge"]
 }


### PR DESCRIPTION
## Description

Add `tailwindFunctions` option for `prettier-plugin-tailwindcss` to sort tailwind classes in `"clsx", "cn", "cx", "twMerge"` function calls

See [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss?tab=readme-ov-file#sorting-classes-in-function-calls)
