### PR TITLE
build: approve ffmpeg & ffprobe installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,27 @@
   "main": "dist-electron/main.js",
   "pnpm": {
     "onlyBuiltDependencies": [
+      "@ffmpeg-installer/darwin-arm64",
+      "@ffmpeg-installer/darwin-x64",
+      "@ffmpeg-installer/linux-arm",
+      "@ffmpeg-installer/linux-arm64",
+      "@ffmpeg-installer/linux-ia32",
+      "@ffmpeg-installer/linux-x64",
+      "@ffmpeg-installer/win32-ia32",
+      "@ffmpeg-installer/win32-x64",
+      "@ffprobe-installer/darwin-arm64",
+      "@ffprobe-installer/darwin-x64",
+      "@ffprobe-installer/linux-arm",
+      "@ffprobe-installer/linux-arm64",
+      "@ffprobe-installer/linux-ia32",
+      "@ffprobe-installer/linux-x64",
+      "@ffprobe-installer/win32-ia32",
+      "@ffprobe-installer/win32-x64",
       "electron"
+    ],
+    "ignoredBuiltDependencies": [
+      "@tailwindcss/oxide",
+      "esbuild"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -109,10 +109,6 @@
       "@ffprobe-installer/win32-ia32",
       "@ffprobe-installer/win32-x64",
       "electron"
-    ],
-    "ignoredBuiltDependencies": [
-      "@tailwindcss/oxide",
-      "esbuild"
     ]
   }
 }


### PR DESCRIPTION
## Description

Approve ffmpeg & ffprobe installer deps for all platforms in pnpm `onlyBuiltDependencies` in the package.json to allow post install scripts to be run. For some reason, ffmpeg & ffprobe was sometimes not available causing conversion and metadata to fail
https://pnpm.io/fr/9.x/package_json#pnpmonlybuiltdependencies