### PR TITLE
fix: check icon color in dark theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -62,7 +62,7 @@
   --color-input: hsl(240 3.7% 15.9%);
   --color-ring: hsl(240 4.9% 83.9%);
 
-  --color-success: 142.1 70.6% 45.3%;
+  --color-success: hsl(142.1 76.2% 36.3%);
 }
 
 @layer base {


### PR DESCRIPTION
## Description

Check icon in file card was not green in dark mode.
This was caused by Tailwind v4 migration in #389 the success color [was not correctly migrated](https://github.com/murgatt/recode-converter/pull/389/files#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eL69) 

**Before**
<img width="347" height="224" alt="Capture d’écran 2025-10-02 à 19 33 23" src="https://github.com/user-attachments/assets/8f50793e-146a-4047-baf3-c29b045b92d7" />

**After**
<img width="292" height="225" alt="Capture d’écran 2025-10-02 à 19 33 36" src="https://github.com/user-attachments/assets/bcb1bc1b-3cf7-43f5-b9cf-ed8aa940ee66" />

## How to test
- Set theme to dark
- Convert a file
