### PR TITLE
fix(app): resolve ffpmeg & ffprobe path after vite 8 migration

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -17,7 +17,8 @@ export default defineConfig({
         entry: 'electron/main.ts',
         vite: {
           build: {
-            rollupOptions: {
+            rolldownOptions: {
+              external: ['@ffmpeg-installer/ffmpeg', '@ffprobe-installer/ffprobe'],
               plugins: [
                 alias({
                   entries: [


### PR DESCRIPTION
## Description

**Problem**
After upgrading to Vite 8, the built app crashes immediately on launch with:
```
A JavaScript error occurred in the main process
Uncaught Exception: undefined: undefined
```

**Root cause**
Vite 8 no longer keeps `@ffmpeg-installer/ffmpeg` and `@ffprobe-installer/ffprobe` external for the Electron main build, so their code gets bundled into `dist-electron/main.js`.

Those packages locate their binary relative to `__dirname`, expecting to sit inside `node_modules/@ffmpeg-installer/....`. Once inlined into `main.js`, `__dirname` points at `dist-electron/` instead, the lookup fails, and the installer executes throw 'Could not find ffmpeg executable…'. Because it throws a plain string rather than an Error, Electron's crash dialog reads error.name / error.message as undefined — hence undefined: undefined, at startup.

The binaries themselves ship and unpack correctly (app.asar.unpacked/node_modules/@ffmpeg-installer/...); only the bundled resolver was broken.

**Fix**
Mark the two installer packages as external in the Electron main build so their require() stays a real runtime require, resolving into the shipped node_modules:

## How to test
- build the app
- the app should start without any error
